### PR TITLE
saturation display button

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,6 @@
 <!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
 
 - [ ] I've read the `CODE_OF_CONDUCT.md` document.
-- [ ] I've updated the code style using `make codestyle`.
+- [ ] I've updated the code style using the `pre-commit hooks`.
 - [ ] I've written tests for all new methods and classes that I created.
 - [ ] I've written the docstring for all the methods and classes that I used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- pre-commit hooks
+- pre-commit hooks.
 - Documentation build using sphinx and breath.
-- editorconfig
-- CMAKE script to find XIMEA API library automatically
+- editorconfig.
+- CMAKE script to find XIMEA API library automatically.
 - install and uninstall targets
-- Creates simple examples in examples/
-- --version flag to print version and build information
+- Creates simple examples in `examples`.
+- --version flag to print version and build information.
+- Tool button to display and hide saturation overlay on graphics.
+- Logs camera temperature to images VLMetadata.
+- Button to check if new cameras have been connected to the system.
 
 ### Changed
 
@@ -28,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Recording on existing file.
+- Potential overflow on multiplication operations.
 
 ## [0.2.0]
 

--- a/resources/dark_amber.css
+++ b/resources/dark_amber.css
@@ -1087,29 +1087,21 @@ QToolBar::separator:vertical {
 QToolButton {
   background: #31363b;
   border: 0px;
-  height: 36px;
-  margin: 3px;
-  padding: 3px;
-  border-right: 12px solid #31363b;
-  border-left: 12px solid #31363b;
+  margin: 1px;
+  padding: 1px;
+  border-radius: 4px;
 }
 
 QToolButton:hover {
   background: #4f5b62;
-  border-right: 12px solid #4f5b62;
-  border-left: 12px solid #4f5b62;
 }
 
 QToolButton:pressed {
   background: #232629;
-  border-right: 12px solid #232629;
-  border-left: 12px solid #232629;
 }
 
 QToolButton:checked {
   background: #4f5b62;
-  border-left: 12px solid #4f5b62;
-  border-right: 12px solid #ffd740;
 }
 
 /*  ------------------------------------------------------------------------  */

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -1,6 +1,6 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
     <qresource prefix="/resources">
-        <file>dark_amber.qss</file>
+        <file>dark_amber.css</file>
     </qresource>
 </RCC>

--- a/resources/theme/active/saturation.svg
+++ b/resources/theme/active/saturation.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 40 41" version="1.1" xmlns="http://www.w3.org/2000/svg"
+     xml:space="preserve"
+     style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;">
+    <g transform="matrix(1,0,0,1,-90,-44)">
+        <g id="contrast_selected" transform="matrix(1,0,0,1,-139.828,44.6328)">
+            <rect x="229.828" y="0" width="40" height="40" style="fill:none;"/>
+            <g>
+                <g transform="matrix(1.06022,0,0,1.06022,228.623,-48.5247)">
+                    <path d="M19.977,81.24C10.822,81.227 3.393,73.791 3.393,64.633C3.393,55.475 10.822,48.038 19.977,48.026" style="fill:none;stroke:rgb(112,112,112);stroke-width:3.77px;"/>
+                </g>
+                <g transform="matrix(1.06022,0,0,1.06022,228.623,-48.5247)">
+                    <path d="M19.977,48.026C19.985,48.026 20.936,48.026 20.943,48.026C30.109,48.026 36.607,55.467 36.607,64.633C36.607,73.798 29.166,81.24 20,81.24C19.992,81.24 19.985,81.24 19.977,81.24" style="fill:rgb(112,112,112);stroke:rgb(112,112,112);stroke-width:3.77px;stroke-linecap:round;"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/theme/disabled/saturation.svg
+++ b/resources/theme/disabled/saturation.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 40 41" version="1.1" xmlns="http://www.w3.org/2000/svg"
+     xml:space="preserve"
+     style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;">
+    <g transform="matrix(1,0,0,1,0,-44)">
+        <g id="contrast_disabled" transform="matrix(1,0,0,1,-229.828,44.6328)">
+            <rect x="229.828" y="0" width="40" height="40" style="fill:none;"/>
+            <g>
+                <g transform="matrix(1.06022,0,0,1.06022,228.623,-48.5247)">
+                    <path d="M19.977,81.24C10.822,81.227 3.393,73.791 3.393,64.633C3.393,55.475 10.822,48.038 19.977,48.026" style="fill:none;stroke:rgb(79,91,98);stroke-width:3.77px;"/>
+                </g>
+                <g transform="matrix(1.06022,0,0,1.06022,228.623,-48.5247)">
+                    <path d="M19.977,48.026C19.985,48.026 20.936,48.026 20.943,48.026C30.109,48.026 36.607,55.467 36.607,64.633C36.607,73.798 29.166,81.24 20,81.24C19.992,81.24 19.985,81.24 19.977,81.24" style="fill:rgb(79,91,98);stroke:rgb(79,91,98);stroke-width:3.77px;stroke-linecap:round;"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/theme/primary/saturation.svg
+++ b/resources/theme/primary/saturation.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 40 41" version="1.1" xmlns="http://www.w3.org/2000/svg"
+     xml:space="preserve"
+     style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;">
+    <g transform="matrix(1,0,0,1,-44,-44)">
+        <g id="contrast_active" transform="matrix(1,0,0,1,-185.828,44.6328)">
+            <rect x="229.828" y="0" width="40" height="40" style="fill:none;"/>
+            <g>
+                <g transform="matrix(1.06022,0,0,1.06022,228.623,-48.5247)">
+                    <path d="M19.977,81.24C10.822,81.227 3.393,73.791 3.393,64.633C3.393,55.475 10.822,48.038 19.977,48.026" style="fill:none;stroke:rgb(255,215,64);stroke-width:3.77px;"/>
+                </g>
+                <g transform="matrix(1.06022,0,0,1.06022,228.623,-48.5247)">
+                    <path d="M19.977,48.026C19.985,48.026 20.936,48.026 20.943,48.026C30.109,48.026 36.607,55.467 36.607,64.633C36.607,73.798 29.166,81.24 20,81.24C19.992,81.24 19.985,81.24 19.977,81.24" style="fill:rgb(255,215,64);stroke:rgb(255,215,64);stroke-width:3.77px;stroke-linecap:round;"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/theme_resources.qrc
+++ b/resources/theme_resources.qrc
@@ -17,6 +17,7 @@
     <file>theme/disabled/checklist_indeterminate_invert.svg</file>
     <file>theme/disabled/checklist_invert.svg</file>
     <file>theme/disabled/close.svg</file>
+    <file>theme/disabled/saturation.svg</file>
     <file>theme/disabled/downarrow.svg</file>
     <file>theme/disabled/downarrow2.svg</file>
     <file>theme/disabled/float.svg</file>
@@ -55,6 +56,7 @@
     <file>theme/primary/checklist_indeterminate_invert.svg</file>
     <file>theme/primary/checklist_invert.svg</file>
     <file>theme/primary/close.svg</file>
+    <file>theme/primary/saturation.svg</file>
     <file>theme/primary/downarrow.svg</file>
     <file>theme/primary/downarrow2.svg</file>
     <file>theme/primary/float.svg</file>
@@ -93,6 +95,7 @@
     <file>theme/active/checklist_indeterminate_invert.svg</file>
     <file>theme/active/checklist_invert.svg</file>
     <file>theme/active/close.svg</file>
+    <file>theme/active/saturation.svg</file>
     <file>theme/active/downarrow.svg</file>
     <file>theme/active/downarrow2.svg</file>
     <file>theme/active/float.svg</file>
@@ -117,6 +120,6 @@
     <file>theme/active/vline.svg</file>
   </qresource>
   <qresource prefix="file">
-    <file>dark_amber.qss</file>
+    <file>dark_amber.css</file>
   </qresource>
 </RCC>

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
 
     // instantiate application
     QApplication a(argc, argv);
-    QFile themeFile(":/resources/dark_amber.qss");
+    QFile themeFile(":/resources/dark_amber.css");
     if (themeFile.open(QFile::ReadOnly | QFile::Text))
     {
         QTextStream stream(&themeFile);

--- a/src/displayFunctional.cpp
+++ b/src/displayFunctional.cpp
@@ -78,21 +78,24 @@ void DisplayerFunctional::PrepareRawImage(cv::Mat &raw_image, bool equalize_hist
     }
     cvtColor(raw_image, raw_image, cv::COLOR_GRAY2RGB);
 
-    // Parallel execution on each pixel using C++11 lambda.
-    raw_image.forEach<Pixel>([mask, this](Pixel &p, const int position[]) -> void {
-        if (mask.at<cv::Vec3b>(position[0], position[1]) == SATURATION_COLOR)
-        {
-            p.x = SATURATION_COLOR[0];
-            p.y = SATURATION_COLOR[1];
-            p.z = SATURATION_COLOR[2];
-        }
-        else if (mask.at<cv::Vec3b>(position[0], position[1]) == DARK_COLOR)
-        {
-            p.x = DARK_COLOR[0];
-            p.y = DARK_COLOR[1];
-            p.z = DARK_COLOR[2];
-        }
-    });
+    if (m_mainWindow->IsSaturationButtonChecked())
+    {
+        // Parallel execution on each pixel using C++11 lambda.
+        raw_image.forEach<Pixel>([mask, this](Pixel &p, const int position[]) -> void {
+            if (mask.at<cv::Vec3b>(position[0], position[1]) == SATURATION_COLOR)
+            {
+                p.x = SATURATION_COLOR[0];
+                p.y = SATURATION_COLOR[1];
+                p.z = SATURATION_COLOR[2];
+            }
+            else if (mask.at<cv::Vec3b>(position[0], position[1]) == DARK_COLOR)
+            {
+                p.x = DARK_COLOR[0];
+                p.y = DARK_COLOR[1];
+                p.z = DARK_COLOR[2];
+            }
+        });
+    }
 }
 
 void DisplayerFunctional::GetBand(cv::Mat &image, cv::Mat &band_image, unsigned int band_nr)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -136,11 +136,18 @@ void MainWindow::EnableUi(bool enable)
 
 void MainWindow::SetUpCustomUiComponents()
 {
-    QIcon buttonIcon;
-    buttonIcon.addFile(":/icon/theme/primary/reload.svg", QSize(), QIcon::Normal);
-    buttonIcon.addFile(":/icon/theme/disabled/reload.svg", QSize(), QIcon::Disabled);
-    buttonIcon.addFile(":/icon/theme/active/reload.svg", QSize(), QIcon::Active);
-    this->ui->reloadCamerasPushButton->setIcon(buttonIcon);
+    // reload camera list button
+    QIcon reloadButtonIcon;
+    reloadButtonIcon.addFile(":/icon/theme/primary/reload.svg", QSize(), QIcon::Normal);
+    reloadButtonIcon.addFile(":/icon/theme/disabled/reload.svg", QSize(), QIcon::Disabled);
+    reloadButtonIcon.addFile(":/icon/theme/active/reload.svg", QSize(), QIcon::Active);
+    this->ui->reloadCamerasPushButton->setIcon(reloadButtonIcon);
+    // contrast tool button
+    QIcon saturationButtonIcon;
+    saturationButtonIcon.addFile(":/icon/theme/primary/saturation.svg", QSize(), QIcon::Normal);
+    saturationButtonIcon.addFile(":/icon/theme/disabled/saturation.svg", QSize(), QIcon::Disabled);
+    saturationButtonIcon.addFile(":/icon/theme/active/saturation.svg", QSize(), QIcon::Active);
+    this->ui->saturationToolButton->setIcon(saturationButtonIcon);
 }
 
 void MainWindow::Display()
@@ -1043,4 +1050,9 @@ void MainWindow::SetGraphicsViewScene()
 {
     this->ui->rgbImageGraphicsView->setScene(this->rgbScene.get());
     this->ui->rawImageGraphicsView->setScene(this->rawScene.get());
+}
+
+bool MainWindow::IsSaturationButtonChecked()
+{
+    return this->ui->saturationToolButton->isChecked();
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -164,6 +164,13 @@ class MainWindow : public QMainWindow
     void UpdateImage(cv::Mat &image, QImage::Format format, QGraphicsView *view,
                      std::unique_ptr<QGraphicsPixmapItem> &pixmapItem, QGraphicsScene *scene);
 
+    /**
+     * Identifies if the saturation tool button is checked or not.
+     *
+     * @return true if the saturation button is checked, false otherwise
+     */
+    bool IsSaturationButtonChecked();
+
   protected:
     /**
      * @brief Event handler for the close event of the main window.

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -212,7 +212,7 @@
                          <string/>
                         </property>
                         <property name="placeholderText">
-                         <string>fodler1, fodler2, ...</string>
+                         <string>folder1, folder2, ...</string>
                         </property>
                        </widget>
                       </item>
@@ -827,13 +827,64 @@
          </widget>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="1,1">
+         <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="0,1,1">
           <property name="spacing">
            <number>0</number>
           </property>
           <property name="leftMargin">
            <number>0</number>
           </property>
+          <item>
+           <layout class="QHBoxLayout" name="graphicsToolsHorizontalLayout">
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QToolButton" name="saturationToolButton">
+              <property name="minimumSize">
+               <size>
+                <width>40</width>
+                <height>40</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Display or hide pixel saturation overlay.</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
+              <property name="arrowType">
+               <enum>Qt::NoArrow</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
           <item>
            <widget class="QGraphicsView" name="rawImageGraphicsView">
             <property name="enabled">


### PR DESCRIPTION
## Description
Adds saturation tool button to hide and display pixel saturation overlay on graphics.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

#6 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
