### PR TITLE
Fix memory access error on 5x5 sensors

### DIFF
--- a/src/displayFunctional.h
+++ b/src/displayFunctional.h
@@ -190,6 +190,14 @@ class DisplayerFunctional : public Displayer
      * @param bgr_image The output BGR image.
      */
     void GetBGRImage(cv::Mat &image, cv::Mat &rgb_image);
+
+    /**
+     * Initializes a channel image based on the raw image.
+     *
+     * @param image The raw image
+     * @return Image filled with 0's with a size capable of holding a band image after demosaic operation is applied
+     */
+    cv::Mat InitializeBandImage(cv::Mat &image);
 };
 
 /**


### PR DESCRIPTION
## Description
Fixes memory access error when mosaic share is not divisible by raw image dimensions.

## Related Issue

#24 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
