### PR TITLE
labeled slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logs camera temperature to images VLMetadata.
 - Button to check if new cameras have been connected to the system.
 - LCD displayer to show frames per second that are stored to file while recording.
+- Custom QSliderLabeled widget to paint text marks on the slider.
 
 ### Changed
 
@@ -27,10 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped the version of CLI11 to 2.4.2.
 - Disallows automatic connections between slots and signals and creates connections explicitly.
 - Logger prints file path instead of just file name.
+- Makes base folder line edit as editable such that base folder can be selected from dialog or by writing the path.
 
 ### Removed
 
 - Unused `RunNetwork` method.
+- Removes base folder from the UI.
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(XILENS_LIB_SRC src/mainwindow.cpp
         src/camera.cpp
         src/logger.cpp
         src/constants.cpp
+        src/widgets.cpp
 )
 set(XILENS_LIB_HDR src/mainwindow.h
         src/cameraInterface.h
@@ -130,6 +131,7 @@ set(XILENS_LIB_HDR src/mainwindow.h
         src/logger.h
         src/xiAPIWrapper.h
         src/constants.h
+        src/widgets.h
 )
 set(XILENS_LIB_UI src/mainwindow.ui)
 
@@ -137,6 +139,7 @@ qt6_wrap_cpp(XILENS_LIB_HDR_MOC ${XILENS_LIB_HDR})
 qt6_wrap_ui(XILENS_LIB_UI_MOC ${XILENS_LIB_UI})
 
 include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_BINARY_DIR})
 
 add_library(XILENS_LIB ${LIBTYPE}

--- a/resources/XiLensCameraProperties.json
+++ b/resources/XiLensCameraProperties.json
@@ -149,6 +149,12 @@
     "mosaicWidth": 0,
     "mosaicHeight": 0
   },
+  "MC050MG-SY-UB": {
+    "cameraType": "gray",
+    "cameraFamily": "xiC",
+    "mosaicWidth": 0,
+    "mosaicHeight": 0
+  },
   "MC051CG-SY-PG4": {
     "cameraType": "rgb",
     "cameraFamily": "xiC",

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -92,10 +92,6 @@ void MainWindow::SetUpConnections()
                                               &MainWindow::handleExposureLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->exposureLineEdit, &QLineEdit::returnPressed, this,
                                               &MainWindow::handleExposureLineEditReturnPressed));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleSubFolderLineEditTextEdited));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleSubFolderLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixLineEdit, &QLineEdit::textEdited, this,
                                               &MainWindow::handleFilePrefixLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixLineEdit, &QLineEdit::returnPressed, this,
@@ -260,10 +256,6 @@ void MainWindow::RecordSnapshots()
     if (filePrefix.empty())
     {
         filePrefix = m_recPrefixLineEdit.toUtf8().constData();
-    }
-    if (subFolder.empty())
-    {
-        subFolder = m_subFolder.toStdString();
     }
     QString filePath = GetFullFilenameStandardFormat(std::move(filePrefix), ".b2nd", std::move(subFolder));
     auto image = m_imageContainer.GetCurrentImage();
@@ -444,7 +436,6 @@ void MainWindow::HandleElementsWhileRecording(bool recordingInProgress)
     if (recordingInProgress)
     {
         QMetaObject::invokeMethod(ui->baseFolderButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
-        QMetaObject::invokeMethod(ui->subFolderLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->filePrefixLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->cameraListComboBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->whiteBalanceButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
@@ -454,7 +445,6 @@ void MainWindow::HandleElementsWhileRecording(bool recordingInProgress)
     else
     {
         QMetaObject::invokeMethod(ui->baseFolderButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
-        QMetaObject::invokeMethod(ui->subFolderLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->filePrefixLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->cameraListComboBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->whiteBalanceButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
@@ -526,12 +516,6 @@ QString MainWindow::LogMessage(const QString &message, const QString &logFile, b
     return timestamp;
 }
 
-void MainWindow::handleSubFolderLineEditReturnPressed()
-{
-    m_subFolder = ui->subFolderLineEdit->text();
-    RestoreLineEditStyle(ui->subFolderLineEdit);
-}
-
 void MainWindow::handleFilePrefixLineEditReturnPressed()
 {
     m_recPrefixLineEdit = ui->filePrefixLineEdit->text();
@@ -581,10 +565,6 @@ void MainWindow::InitializeImageFileRecorder(std::string subFolder, std::string 
     if (filePrefix.empty())
     {
         filePrefix = m_recPrefixLineEdit.toUtf8().constData();
-    }
-    if (subFolder.empty())
-    {
-        subFolder = m_subFolder.toStdString();
     }
     QString fullPath = GetFullFilenameStandardFormat(std::move(filePrefix), ".b2nd", std::move(subFolder));
     this->m_imageContainer.InitializeFile(fullPath.toStdString().c_str());
@@ -878,11 +858,6 @@ void MainWindow::UpdateComponentEditedStyle(QLineEdit *lineEdit, const QString &
 void MainWindow::RestoreLineEditStyle(QLineEdit *lineEdit)
 {
     lineEdit->setStyleSheet(FIELD_ORIGINAL_STYLE);
-}
-
-void MainWindow::handleSubFolderLineEditTextEdited(const QString &newText)
-{
-    UpdateComponentEditedStyle(ui->subFolderLineEdit, newText, m_subFolder);
 }
 
 void MainWindow::handleFilePrefixLineEditTextEdited(const QString &newText)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -116,8 +116,12 @@ void MainWindow::SetUpConnections()
                                               &MainWindow::handleFilePrefixExtrasLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixExtrasLineEdit, &QLineEdit::returnPressed, this,
                                               &MainWindow::handleFilePrefixExtrasLineEditReturnPressed));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::returnPressed, this,
+                                              &MainWindow::handleBaseFolderLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderExtrasLineEdit, &QLineEdit::textEdited, this,
                                               &MainWindow::handleSubFolderExtrasLineEditTextEdited));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::textEdited, this,
+                                              &MainWindow::handleBaseFolderLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderExtrasLineEdit, &QLineEdit::returnPressed, this,
                                               &MainWindow::handleSubFolderExtrasLineEditReturnPressed));
 }
@@ -389,19 +393,6 @@ void MainWindow::UpdateExposure()
     ui->exposureSlider->setValue(exp_ms);
 }
 
-void MainWindow::handleExposureLineEditReturnPressed()
-{
-    m_labelExp = ui->exposureLineEdit->text();
-    m_cameraInterface.m_camera->SetExposureMs(m_labelExp.toInt());
-    UpdateExposure();
-    RestoreLineEditStyle(ui->exposureLineEdit);
-}
-
-void MainWindow::handleExposureLineEditTextEdited(const QString &arg1)
-{
-    UpdateComponentEditedStyle(ui->exposureLineEdit, arg1, m_labelExp);
-}
-
 void MainWindow::handleRecordButtonClicked(bool clicked)
 {
     static QString original_colour;
@@ -441,6 +432,7 @@ void MainWindow::HandleElementsWhileRecording(bool recordingInProgress)
         QMetaObject::invokeMethod(ui->whiteBalanceButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->darkCorrectionButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->reloadCamerasPushButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
+        QMetaObject::invokeMethod(ui->baseFolderLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
     }
     else
     {
@@ -450,6 +442,7 @@ void MainWindow::HandleElementsWhileRecording(bool recordingInProgress)
         QMetaObject::invokeMethod(ui->whiteBalanceButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->darkCorrectionButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->reloadCamerasPushButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
+        QMetaObject::invokeMethod(ui->baseFolderLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
     }
 }
 
@@ -514,12 +507,6 @@ QString MainWindow::LogMessage(const QString &message, const QString &logFile, b
     stream << message << "\n";
     file.close();
     return timestamp;
-}
-
-void MainWindow::handleFilePrefixLineEditReturnPressed()
-{
-    m_recPrefixLineEdit = ui->filePrefixLineEdit->text();
-    RestoreLineEditStyle(ui->filePrefixLineEdit);
 }
 
 bool MainWindow::GetNormalize() const
@@ -860,14 +847,18 @@ void MainWindow::RestoreLineEditStyle(QLineEdit *lineEdit)
     lineEdit->setStyleSheet(FIELD_ORIGINAL_STYLE);
 }
 
-void MainWindow::handleFilePrefixLineEditTextEdited(const QString &newText)
+void MainWindow::handleExposureLineEditReturnPressed()
 {
-    UpdateComponentEditedStyle(ui->filePrefixLineEdit, newText, m_recPrefixLineEdit);
+    m_labelExp = ui->exposureLineEdit->text();
+    m_cameraInterface.m_camera->SetExposureMs(m_labelExp.toInt());
+    UpdateExposure();
+    RestoreLineEditStyle(ui->exposureLineEdit);
 }
 
-void MainWindow::handleSubFolderExtrasLineEditTextEdited(const QString &newText)
+void MainWindow::handleFilePrefixLineEditReturnPressed()
 {
-    UpdateComponentEditedStyle(ui->subFolderExtrasLineEdit, newText, m_extrasSubFolder);
+    m_recPrefixLineEdit = ui->filePrefixLineEdit->text();
+    RestoreLineEditStyle(ui->filePrefixLineEdit);
 }
 
 void MainWindow::handleSubFolderExtrasLineEditReturnPressed()
@@ -876,27 +867,16 @@ void MainWindow::handleSubFolderExtrasLineEditReturnPressed()
     RestoreLineEditStyle(ui->subFolderExtrasLineEdit);
 }
 
-void MainWindow::handleFilePrefixExtrasLineEditTextEdited(const QString &newText)
-{
-    UpdateComponentEditedStyle(ui->filePrefixExtrasLineEdit, newText, m_extrasFilePrefix);
-}
-
 void MainWindow::handleFilePrefixExtrasLineEditReturnPressed()
 {
     m_extrasFilePrefix = ui->filePrefixExtrasLineEdit->text();
     RestoreLineEditStyle(ui->filePrefixExtrasLineEdit);
 }
 
-void MainWindow::handleLogTextLineEditTextEdited(const QString &newText)
+void MainWindow::handleBaseFolderLineEditReturnPressed()
 {
-    UpdateComponentEditedStyle(ui->logTextLineEdit, newText, m_triggerText);
-}
-
-QString MainWindow::FormatTimeStamp(const QString &timestamp)
-{
-    QDateTime dateTime = QDateTime::fromString(timestamp, "yyyyMMdd_HH-mm-ss-zzz");
-    QString formattedDate = dateTime.toString("hh:mm:ss AP");
-    return formattedDate;
+    m_baseFolderLoc = ui->baseFolderLineEdit->text();
+    RestoreLineEditStyle(ui->baseFolderLineEdit);
 }
 
 void MainWindow::handleLogTextLineEditReturnPressed()
@@ -918,6 +898,43 @@ void MainWindow::handleLogTextLineEditReturnPressed()
     ui->logTextEdit->append(m_triggerText);
     ui->logTextEdit->show();
     ui->logTextLineEdit->clear();
+}
+
+void MainWindow::handleFilePrefixLineEditTextEdited(const QString &newText)
+{
+    UpdateComponentEditedStyle(ui->filePrefixLineEdit, newText, m_recPrefixLineEdit);
+}
+
+void MainWindow::handleSubFolderExtrasLineEditTextEdited(const QString &newText)
+{
+    UpdateComponentEditedStyle(ui->subFolderExtrasLineEdit, newText, m_extrasSubFolder);
+}
+
+void MainWindow::handleExposureLineEditTextEdited(const QString &newText)
+{
+    UpdateComponentEditedStyle(ui->exposureLineEdit, newText, m_labelExp);
+}
+
+void MainWindow::handleFilePrefixExtrasLineEditTextEdited(const QString &newText)
+{
+    UpdateComponentEditedStyle(ui->filePrefixExtrasLineEdit, newText, m_extrasFilePrefix);
+}
+
+void MainWindow::handleLogTextLineEditTextEdited(const QString &newText)
+{
+    UpdateComponentEditedStyle(ui->logTextLineEdit, newText, m_triggerText);
+}
+
+void MainWindow::handleBaseFolderLineEditTextEdited(const QString &newText)
+{
+    UpdateComponentEditedStyle(ui->baseFolderLineEdit, newText, m_baseFolderLoc);
+}
+
+QString MainWindow::FormatTimeStamp(const QString &timestamp)
+{
+    QDateTime dateTime = QDateTime::fromString(timestamp, "yyyyMMdd_HH-mm-ss-zzz");
+    QString formattedDate = dateTime.toString("hh:mm:ss AP");
+    return formattedDate;
 }
 
 /*

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -41,22 +41,24 @@ class MainWindow : public QMainWindow
     ~MainWindow() override;
 
     /**
-     * Queries if normalization should be applied to the displayed images
+     * Queries if normalization should be applied to the displayed images.
      */
     bool GetNormalize() const;
 
     /**
-     * Queries the band number to be displayed
+     * Queries the band number to be displayed.
      */
     virtual unsigned GetBand() const;
 
     /**
-     * Queries the normalization factor to be used
+     * Queries the normalization factor to be used.
      */
     unsigned GetBGRNorm() const;
 
     /**
-     * Enables the UI elements
+     * Enables the UI elements.
+     *
+     * @param enable indicates if UI is enabled or not.
      */
     void EnableUi(bool enable);
 
@@ -66,60 +68,72 @@ class MainWindow : public QMainWindow
     void SetUpCustomUiComponents();
 
     /**
-     * Disables the UI elements
+     * Disables the UI elements.
+     *
+     * @param layout layout where elements will be enabled or disabled.
+     * @param enable indicates if elements should ne enabled or disabled.
      */
     void EnableWidgetsInLayout(QLayout *layout, bool enable);
 
     /**
-     * Writes general information as header of the log file
+     * Writes general information as header of the log file.
      */
     void WriteLogHeader();
 
     /**
-     * Logs message to log file and returns the timestamp used during logging
+     * Logs message to log file and returns the timestamp used during logging.
+     *
+     * @param message message to be logged.
+     * @param logFile file name where the message should be logged.
+     * @param logTime whether time should be logged too or not.
      */
     QString LogMessage(const QString &message, const QString &logFile, bool logTime);
 
     /**
-     * Queries the path where the logfile is stored
+     * Queries the path where the logfile is stored.
      *
-     * @return
+     * @param logFile file name.
+     * @return path to file.
      */
     QString GetLogFilePath(const QString &logFile);
 
     /**
-     * Gets camera temperature
+     * Gets camera temperature.
+     *
+     * @return mapper containing the camera temperature with keys identifying the location on the camera where the
+     * temperature was queried from.
      */
     QMap<QString, float> GetCameraTemperature() const;
 
     /**
-     * Displays camera temperature on an LCD display
+     * Displays camera temperature on an LCD display.
      */
     void DisplayCameraTemperature();
 
     /**
-     * Creates schedule for the thread in charge of logging temperature of the
-     * camera
+     * Creates schedule for the thread in charge of logging temperature of the camera.
      */
     void ScheduleTemperatureThread();
 
     /**
-     * Starts the thread in charge of logging camera temperature
+     * Starts the thread in charge of logging camera temperature.
      */
     void StartTemperatureThread();
 
     /**
-     * Stops thread in charge of logging camera temperature
+     * Stops thread in charge of logging camera temperature.
      */
     void StopTemperatureThread();
 
     /**
-     * Handle for timer used to schedule camera temperature logging
+     * Handle for timer used to schedule camera temperature logging.
+     *
+     * @param error type of error expected to cancel the timer.
      */
     void HandleTemperatureTimer(const boost::system::error_code &error);
 
     /**
-     * Stops thread in charge of recording snapshot images
+     * Stops thread in charge of recording snapshot images.
      */
     void StopSnapshotsThread();
 
@@ -127,8 +141,7 @@ class MainWindow : public QMainWindow
      * @brief Updates the saturation percentage on the LCD displays.
      *
      * @param image The input image of type CV_8UC1. It must be non-empty.
-     * @throws std::invalid_argument if the input matrix is empty or of the wrong
-     * type.
+     * @throws std::invalid_argument if the input matrix is empty or of the wrong type.
      */
     void UpdateSaturationPercentageLCDDisplays(cv::Mat &image) const;
 
@@ -138,16 +151,16 @@ class MainWindow : public QMainWindow
     void UpdateFPSLCDDisplay();
 
     /**
-     * Updates the RGB image displayed in the GUI
+     * Updates the RGB image displayed in the GUI.
      *
-     * @param image OpenCv matrix containing an 8bit (per channel) RGB image to be displayed
+     * @param image OpenCv matrix containing an 8bit (per channel) RGB image to be displayed.
      */
     void UpdateRGBImage(cv::Mat &image);
 
     /**
-     * Updates the raw image displayed in the GUI
+     * Updates the raw image displayed in the GUI.
      *
-     * @param image OpenCV matrix containing an 8bit single channel image to be displayed
+     * @param image OpenCV matrix containing an 8bit single channel image to be displayed.
      */
     void UpdateRawImage(cv::Mat &image);
 
@@ -155,11 +168,11 @@ class MainWindow : public QMainWindow
      * Takes an image, and scales it to the available width in the QtGraphicsView element before displaying it in the
      * provided scene.
      *
-     * @param image OpenCV matrix to be displayed
-     * @param format format expected of the image, for example `QImage::Format_RGB888` for an 8bit RGB image
-     * @param view the graphics view element where image will be displayed
-     * @param pixmapItem pixmap item where the image is to be placed
-     * @param scene the scene that will contain the pixmap
+     * @param image OpenCV matrix to be displayed.
+     * @param format format expected of the image, for example `QImage::Format_RGB888` for an 8bit RGB image.
+     * @param view the graphics view element where image will be displayed.
+     * @param pixmapItem pixmap item where the image is to be placed.
+     * @param scene the scene that will contain the pixmap.
      */
     static void UpdateImage(cv::Mat &image, QImage::Format format, QGraphicsView *view,
                             std::unique_ptr<QGraphicsPixmapItem> &pixmapItem, QGraphicsScene *scene);
@@ -167,7 +180,7 @@ class MainWindow : public QMainWindow
     /**
      * Identifies if the saturation tool button is checked or not.
      *
-     * @return true if the saturation button is checked, false otherwise
+     * @return true if the saturation button is checked, false otherwise.
      */
     bool IsSaturationButtonChecked();
 
@@ -184,12 +197,12 @@ class MainWindow : public QMainWindow
     /**
      * Sets the number of images recorded.
      *
-     * @param count number of recorded images
+     * @param count number of recorded images.
      */
     void SetRecordedCount(int count);
 
     /**
-     * Displays the number of recorded images in the GUI
+     * Displays the number of recorded images in the GUI.
      */
     void DisplayRecordCount();
 
@@ -224,6 +237,8 @@ class MainWindow : public QMainWindow
 
     /**
      * Qt slot triggered when the camera exposure slider is modified.
+     *
+     * @param value exposure value.
      */
     void handleExposureSliderValueChanged(int value);
 
@@ -231,6 +246,8 @@ class MainWindow : public QMainWindow
      * Qt slot triggered when the record button is pressed. Stars the continuous
      * recording of images to files and stops it when pressed a second time. This
      * is synchronized with the exposure time label.
+     *
+     * @param clicked indicates if the button is clicked.
      */
     void handleRecordButtonClicked(bool clicked);
 
@@ -244,8 +261,10 @@ class MainWindow : public QMainWindow
      * Qt slot triggered when the exposure time labels is modified manually. This
      * changes the appearance of the field but does not trigger the change in the
      * camera. Return key needs to be pressed for the change to be applied.
+     *
+     * @param newText edited text.
      */
-    void handleExposureLineEditTextEdited(const QString &arg1);
+    void handleExposureLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when return key is pressed after modifying the exposure
@@ -264,6 +283,8 @@ class MainWindow : public QMainWindow
      * Qt slot triggered when the prefix file name is edited. It changes the
      * appearance of the field in the UI. It does not change the value of the
      * member variable that stores the file prefix name.
+     *
+     * @param newText edited text.
      */
     void handleFilePrefixLineEditTextEdited(const QString &newText);
 
@@ -288,6 +309,8 @@ class MainWindow : public QMainWindow
     /**
      * Qt slot triggered when the trigger text is edited. It only changes the
      * appearance of the UI element.
+     *
+     * @param newText edited text.
      */
     void handleLogTextLineEditTextEdited(const QString &newText);
 
@@ -305,6 +328,8 @@ class MainWindow : public QMainWindow
 
     /**
      * Qt slot triggered when a new camera is selected from the drop-down menu.
+     *
+     * @param index index corresponding to the element selected from the combo box.
      */
     void handleCameraListComboBoxCurrentIndexChanged(int index);
 
@@ -315,6 +340,8 @@ class MainWindow : public QMainWindow
 
     /**
      * Qt slot triggered when file name prefix for snapshots is edited on the UI.
+     *
+     * @param newText edited text.
      */
     void handleFilePrefixExtrasLineEditTextEdited(const QString &newText);
 
@@ -325,9 +352,23 @@ class MainWindow : public QMainWindow
     void handleFilePrefixExtrasLineEditReturnPressed();
 
     /**
+     * Qt slot triggered when the return key is pressed on the base folder field line edit in the UI.
+     */
+    void handleBaseFolderLineEditReturnPressed();
+
+    /**
      * Qt slot triggered when extras sub folder field is edited in the UI.
+     *
+     * @param newText edited text.
      */
     void handleSubFolderExtrasLineEditTextEdited(const QString &newText);
+
+    /**
+     * Qt slot triggered when base folder field is edited in the UI.
+     *
+     * @param newText edited text.
+     */
+    void handleBaseFolderLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when the return key is pressed on the sub folder field in
@@ -338,46 +379,57 @@ class MainWindow : public QMainWindow
   private:
     void SetUpConnections();
 
+    /**
+     * Handles the result emanating from a Qt connection attempt.
+     *
+     * @param status status returned by `QObject::connect`.
+     * @param file file that calls this method.
+     * @param line line where this method is called from.
+     * @param func function name that calls this method.
+     */
     static void HandleConnectionResult(bool status, const char *file, int line, const char *func);
 
     /**
-     * Records the white reference to a folder called "white"
+     * Records the white reference to a folder called "white".
+     *
+     * @param referenceType type of reference `white` or `dark`.
      */
     void RecordReferenceImages(const QString &referenceType);
 
     /**
-     * Stops the thread responsible for recording the reference images (white and
-     * dark)
+     * Stops the thread responsible for recording the reference images (white and dark).
      */
     void StopReferenceRecordingThread();
 
     /**
      * Updates the stile of a Qt LineEdit component.
      *
-     * @param lineEdit element to update
-     * @param newString new value received from element
-     * @param originalString original value of hte element before changes occurred
+     * @param lineEdit element to update.
+     * @param newString new value received from element.
+     * @param originalString original value of hte element before changes occurred.
      */
     static void UpdateComponentEditedStyle(QLineEdit *lineEdit, const QString &newString,
                                            const QString &originalString);
 
     /**
      * Restores the appearance of a Qt LineEdit component.
+     *
+     * @param lineEdit line edit for which style should be restored.
      */
     static void RestoreLineEditStyle(QLineEdit *lineEdit);
 
     /**
-     * @brief Displays a new image
+     * @brief Displays a new image.
      */
     void Display();
 
     /**
-     * Starts the recording process
+     * Starts the recording process.
      */
     void StartRecording();
 
     /**
-     * Stops the recording process
+     * Stops the recording process.
      */
     void StopRecording();
 
@@ -393,20 +445,24 @@ class MainWindow : public QMainWindow
 
     /**
      * Sets the base folder path where the data is to be stored.
+     *
+     * @param baseFolderPath path of base folder where data will be stored.
      */
     bool SetBaseFolder(const QString &baseFolderPath);
 
     /**
-     * Creates a folder if it does not exist
+     * Creates a folder if it does not exist.
+     *
+     * @param folder the path to folder that needs to be created.
      */
     static void CreateFolderIfNecessary(const QString &folder);
 
     /**
      * Records image to specified sub folder and using specified file prefix to
-     * name the file
+     * name the file.
      *
      * @param ignoreSkipping ignores the number of frames to skip and stores the
-     * image anyways
+     * image anyways.
      */
     void RecordImage(bool ignoreSkipping);
 
@@ -419,23 +475,23 @@ class MainWindow : public QMainWindow
      * Initializes the file object inside the image container. This object is used
      * to store all images while recording to a single file.
      *
-     * @param subFolder folder where data will be stored
-     * @param filePrefix file prefix used for the file name
+     * @param subFolder folder where data will be stored.
+     * @param filePrefix file prefix used for the file name.
      */
     void InitializeImageFileRecorder(std::string subFolder = "", std::string filePrefix = "");
 
     /**
      * Indicates if an image should be recorded to file or not depending on the
-     * frame number and the number of frames to skip
+     * frame number and the number of frames to skip.
      *
-     * @param nSkipFrames number of frames to skip
-     * @param ImageID frame number
-     * @return true if image should be recorded to file or false if not
+     * @param nSkipFrames number of frames to skip.
+     * @param ImageID frame number.
+     * @return true if image should be recorded to file or false if not.
      */
     static bool ImageShouldBeRecorded(int nSkipFrames, long ImageID);
 
     /**
-     * Updates image counter
+     * Updates image counter.
      */
     void CountImages();
 
@@ -450,45 +506,44 @@ class MainWindow : public QMainWindow
     void stopTimer();
 
     /**
-     * @brief RecordSnapshots helper method to take snapshots, basically just
-     * created to be able to thread the snapshot making :-)
+     * @brief MEthod used to record singe snapshot images while recording.
      */
     void RecordSnapshots();
 
     /**
      * @brief UpdateExposure Synchronizes the sliders and text edits displaying
-     * the current exposure setting
+     * the current exposure setting.
      */
     void UpdateExposure();
 
     /**
      * Enables and disables elements of the GUI that should not me modified while
-     * recordings are in progress
+     * recordings are in progress.
      *
-     * @param recordingInProgress
+     * @param recordingInProgress indicates if recordings are happening or not.
      */
     void HandleElementsWhileRecording(bool recordingInProgress);
 
     /**
      * @brief MainWindow::GetWritingFolder returns the folder there the image
-     * files are written to
-     * @return
+     * files are written to.
+     *
+     * @return folder where data is to be stored.
      */
     QString GetWritingFolder();
 
     /**
      * @brief GetFullFilenameStandardFormat returns the full filename of the
-     * current file which shall be written
+     * current file which shall be written.
      *
      * It automatically add the current write path and puts the name in a standard
      * format including timestamp etc.
      *
-     * @param filePrefix the name of the file (snapshot, recording, liver_image,
-     * ...)
-     * @param frameNumber the acquisition frame number provided by ximea
-     * @param extension file extension (.dat or .tif)
-     * @param subFolder sometimes we want to add an additional layer of subfolder,
-     * specifically when saving white/dark balance images
+     * @param filePrefix the name of the file (snapshot, recording, liver_image, ...).
+     * @param frameNumber the acquisition frame number provided by ximea.
+     * @param extension file extension (.b2nd).
+     * @param subFolder sometimes we want to add an additional layer of subfolder.
+     * specifically when saving white/dark balance images.
      * @return
      */
     QString GetFullFilenameStandardFormat(std::string &&filePrefix, const std::string &extension,
@@ -512,10 +567,10 @@ class MainWindow : public QMainWindow
 
     /**
      * Formats timestamp tag from format  yyyyMMdd_HH-mm-ss-zzz into a human
-     * readable format
+     * readable format.
      *
-     * @param timestamp
-     * @return
+     * @param timestamp time stamp to be formatted.
+     * @return formatted timestamp.
      */
     static QString FormatTimeStamp(const QString &timestamp);
 
@@ -591,7 +646,7 @@ class MainWindow : public QMainWindow
     QString m_maxSao2;
 
     /**
-     * Image container where each new image from the camera is stored
+     * Image container where each new image from the camera is stored.
      */
     ImageContainer m_imageContainer;
 
@@ -601,7 +656,7 @@ class MainWindow : public QMainWindow
     CameraInterface m_cameraInterface;
 
     /**
-     * Wrapper to xiAPI, useful for mocking during testing
+     * Wrapper to xiAPI, useful for mocking during testing.
      */
     std::shared_ptr<XiAPIWrapper> m_xiAPIWrapper = std::make_shared<XiAPIWrapper>();
 
@@ -627,12 +682,12 @@ class MainWindow : public QMainWindow
     boost::asio::io_service m_IOService;
 
     /**
-     * Work object to control safe finish of IOService
+     * Work object to control safe finish of IOService.
      */
     std::unique_ptr<boost::asio::io_service::work> m_IOWork;
 
     /**
-     * ID service for recording temperature to file
+     * ID service for recording temperature to file.
      */
     boost::asio::io_service m_temperatureIOService;
 
@@ -663,7 +718,7 @@ class MainWindow : public QMainWindow
     boost::thread m_snapshotsThread;
 
     /**
-     * thread where white and dark references are recorded
+     * thread where white and dark references are recorded.
      */
     boost::thread m_referenceRecordingThread;
 
@@ -678,7 +733,7 @@ class MainWindow : public QMainWindow
     std::atomic<unsigned long> m_recordedCount;
 
     /**
-     * Counts how many images whould have been recorded
+     * Counts how many images would have been recorded.
      */
     std::atomic<unsigned long> m_imageCounter;
 
@@ -693,32 +748,32 @@ class MainWindow : public QMainWindow
     std::deque<std::chrono::steady_clock::time_point> m_recordedTimestamps;
 
     /**
-     * Smart pointer to the RGB scene where the RGB images will be displayed
+     * Smart pointer to the RGB scene where the RGB images will be displayed.
      */
     std::unique_ptr<QGraphicsScene> rgbScene = std::make_unique<QGraphicsScene>(this);
 
     /**
-     * smart pointer to raw scene where the raw unprocessed images will be displayed
+     * smart pointer to raw scene where the raw unprocessed images will be displayed.
      */
     std::unique_ptr<QGraphicsScene> rawScene = std::make_unique<QGraphicsScene>(this);
 
     /**
-     * smart pointer to pixmap used to display the RGB images
+     * smart pointer to pixmap used to display the RGB images.
      */
     std::unique_ptr<QGraphicsPixmapItem> rgbPixMapItem;
 
     /**
-     * Smart pointer to pixmap where raw unprocessed images will be displayed
+     * Smart pointer to pixmap where raw unprocessed images will be displayed.
      */
     std::unique_ptr<QGraphicsPixmapItem> rawPixMapItem;
 
     /**
-     * Sets the scene for RGB and raw image viewers. It defines antialiasing and smooth pixmap transformations
+     * Sets the scene for RGB and raw image viewers. It defines antialiasing and smooth pixmap transformations.
      */
     void SetGraphicsViewScene();
 
     /**
-     * Appends the current time to que of recorded time stamps that can be used to calculate the frames per second
+     * Appends the current time to que of recorded time stamps that can be used to calculate the frames per second.
      */
     void RegisterTimeImageRecorded();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -254,20 +254,6 @@ class MainWindow : public QMainWindow
     void handleExposureLineEditReturnPressed();
 
     /**
-     * Qt slot triggered when return key is pressed on the field where the top
-     * folder is defined in the UI. It updates the member variable that stores the
-     * value.
-     */
-    void handleSubFolderLineEditReturnPressed();
-
-    /**
-     * Qt slot triggered when editing the top folder name. It changes the
-     * appearance of the field in the UI. It does not change the value of hte
-     * member variable that contains the top folder name.
-     */
-    void handleSubFolderLineEditTextEdited(const QString &newText);
-
-    /**
      * Qt slot triggered when the return key is pressed on the field that defines
      * the file prefix in the UI. It updates the member variable that stores the
      * value.
@@ -532,12 +518,6 @@ class MainWindow : public QMainWindow
      * @return
      */
     static QString FormatTimeStamp(const QString &timestamp);
-
-    /**
-     * stores the folder name where images are to be stores. This is a folder
-     * inside of base folder.
-     */
-    QString m_subFolder;
 
     /**
      * file prefix to be appended to each image file name.

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -173,13 +173,13 @@
                       <item>
                        <widget class="QLineEdit" name="baseFolderLineEdit">
                         <property name="toolTip">
-                         <string>Folder where all data is organized</string>
+                         <string>Folder where all data is stored</string>
                         </property>
                         <property name="readOnly">
-                         <bool>true</bool>
+                         <bool>false</bool>
                         </property>
                         <property name="placeholderText">
-                         <string>Base folder where all recordings are saved</string>
+                         <string>Base folder where all data is stored</string>
                         </property>
                        </widget>
                       </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -77,7 +77,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Main recording controls</string>
+            <string/>
            </property>
            <attribute name="title">
             <string>Recording</string>
@@ -144,7 +144,7 @@
                    </layout>
                   </item>
                   <item>
-                   <layout class="QVBoxLayout" name="mainUiVerticalLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+                   <layout class="QVBoxLayout" name="mainUiVerticalLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
                     <item>
                      <widget class="Line" name="fileNameSeparatorLine">
                       <property name="orientation">
@@ -213,39 +213,6 @@
                         </property>
                         <property name="placeholderText">
                          <string>file1, file2, ...</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_2">
-                      <item>
-                       <widget class="QLabel" name="subFolderLabel">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="toolTip">
-                         <string>Folder where files will be stored (created inside save folder)</string>
-                        </property>
-                        <property name="text">
-                         <string>File Folder Name</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLineEdit" name="subFolderLineEdit">
-                        <property name="toolTip">
-                         <string>Folder where files will be stored (inside save folder)</string>
-                        </property>
-                        <property name="text">
-                         <string/>
-                        </property>
-                        <property name="placeholderText">
-                         <string>folder1, folder2, ...</string>
                         </property>
                        </widget>
                       </item>
@@ -1119,7 +1086,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>filePrefixLineEdit</tabstop>
-  <tabstop>subFolderLineEdit</tabstop>
   <tabstop>baseFolderButton</tabstop>
   <tabstop>baseFolderLineEdit</tabstop>
   <tabstop>recordButton</tabstop>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -486,7 +486,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSlider" name="rgbNormSlider">
+                     <widget class="QSliderLabeled" name="rgbNormSlider">
                       <property name="toolTip">
                        <string>Select the normalizing factor for RGB noormalization</string>
                       </property>
@@ -508,6 +508,9 @@
                       <property name="tickPosition">
                        <enum>QSlider::TicksBelow</enum>
                       </property>
+                      <property name="tickInterval">
+                       <number>1</number>
+                      </property>
                      </widget>
                     </item>
                     <item>
@@ -524,7 +527,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSlider" name="bandSlider">
+                     <widget class="QSliderLabeled" name="bandSlider">
                       <property name="toolTip">
                        <string>Select displayed spectral band</string>
                       </property>
@@ -575,7 +578,7 @@
                  </layout>
                 </item>
                 <item>
-                 <widget class="QSlider" name="exposureSlider">
+                 <widget class="QSliderLabeled" name="exposureSlider">
                   <property name="toolTip">
                    <string>Select exposure time</string>
                   </property>
@@ -1107,6 +1110,13 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QSliderLabeled</class>
+   <extends>QSlider</extends>
+   <header>widgets.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>filePrefixLineEdit</tabstop>
   <tabstop>subFolderLineEdit</tabstop>

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -1,0 +1,128 @@
+/*******************************************************
+ * Author: Intelligent Medical Systems
+ * License: see LICENSE.md file
+ *******************************************************/
+
+#include <QColor>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QSlider>
+#include <QStyle>
+#include <QStyleOptionSlider>
+#include <QToolTip>
+
+#include "widgets.h"
+
+QSliderLabeled::QSliderLabeled(QWidget *parent) : QSlider(parent)
+{
+}
+
+void QSliderLabeled::applyStyleSheet()
+{
+    QFontMetrics fm(font());
+    QString maxLabel = QString::number(maximum());
+    int textWidth = fm.horizontalAdvance(maxLabel);
+    int textHeight = fm.height();
+
+    if (orientation() == Qt::Orientation::Horizontal)
+    {
+        setStyleSheet(QString("QSlider{"
+                              " min-height: %1px;"
+                              " max-height: %2px;"
+                              " padding-top: %3px;"
+                              "}")
+                          .arg(m_sliderSpread + textHeight)
+                          .arg(m_sliderSpread + textHeight)
+                          .arg(-m_sliderSpread / 2));
+    }
+    else if (orientation() == Qt::Orientation::Vertical)
+    {
+        setStyleSheet(QString("QSlider{"
+                              " min-width: %1px;"
+                              " max-width: %2px;"
+                              " padding-right: %3px;"
+                              "}")
+                          .arg(m_sliderSpread + textWidth)
+                          .arg(m_sliderSpread + textWidth)
+                          .arg(-m_sliderSpread / 2));
+    }
+}
+
+void QSliderLabeled::paintEvent(QPaintEvent *event)
+{
+    QSlider::paintEvent(event);
+    QPainter painter(this);
+    painter.setPen(m_penColor);
+
+    int min = minimum();
+    int max = maximum();
+    int interval = tickInterval();
+    auto intervalAtMaxLabels = (max - min) / m_maxNumberOfLabels;
+    // Modify the interval if the current interval would generate too many labels in the slider.
+    if (interval == 0 || (max - min) / interval > m_maxNumberOfLabels)
+    {
+        interval = intervalAtMaxLabels;
+    }
+
+    if (orientation() == Qt::Horizontal)
+    {
+        for (int i = min; i <= max; i += interval)
+        {
+            int xpos = QStyle::sliderPositionFromValue(min, max, i, width() - 2 * m_grooveMargin) + m_grooveMargin;
+            QString label = QString::number(i);
+            int textWidth = painter.fontMetrics().horizontalAdvance(label);
+
+            // Ensure labels are not drawn off the widget's area
+            xpos = qBound(0, xpos, width()) - textWidth / 2;
+
+            // Adjust the y position to properly fit the text below the slider
+            painter.drawText(xpos, height(), label);
+        }
+    }
+    else if (orientation() == Qt::Vertical)
+    {
+        for (int i = min; i <= max; i += interval)
+        {
+            int ypos =
+                height() - QStyle::sliderPositionFromValue(min, max, i, height() - 2 * m_grooveMargin) - m_grooveMargin;
+            QString label = QString::number(i);
+
+            // to position the text, we need the bounding box and not just the text height
+            QRect textRect = painter.fontMetrics().tightBoundingRect(label);
+            int textHeight = textRect.height();
+
+            // Ensure labels are not drawn off the widget's area
+            ypos = qBound(0, ypos, height()) + textHeight / 2;
+
+            // Adjust the x position to properly fit the text to the side of the slider
+            painter.drawText(0, ypos, label);
+        }
+    }
+}
+
+void QSliderLabeled::mouseMoveEvent(QMouseEvent *event)
+{
+    QToolTip::showText(event->globalPosition().toPoint(), QString::number(value()), this);
+    QSlider::mouseMoveEvent(event);
+}
+
+void QSliderLabeled::updatePainterPen()
+{
+    QColor penColor = isEnabled() ? QColor(255, 215, 64) : QColor(79, 91, 98);
+    m_penColor = penColor;
+}
+
+void QSliderLabeled::setGrooveMargin(int value)
+{
+    m_grooveMargin = value;
+}
+
+void QSliderLabeled::setMaxNumberOfLabels(int value)
+{
+    m_maxNumberOfLabels = value;
+}
+
+void QSliderLabeled::setSliderSpread(int value)
+{
+    m_sliderSpread = value;
+}

--- a/src/widgets.h
+++ b/src/widgets.h
@@ -1,0 +1,141 @@
+/*******************************************************
+ * Author: Intelligent Medical Systems
+ * License: see LICENSE.md file
+ *******************************************************/
+
+#ifndef XILENS_WIDGETS_H
+#define XILENS_WIDGETS_H
+
+#include <QColor>
+#include <QEvent>
+#include <QSlider>
+#include <QStyle>
+
+/**
+ * Custom slider widget that displays text corresponding to values in the slider.
+ * By default the number of text labels in the slider is set to a maximum of `8`.
+ * If the calculated number of labels based on the interval and the min and max values in the slider exceed this value,
+ * the number of labels is caped.
+ *
+ * The text is centered on the corresponding value of the slider while taking into account the groove margins.
+ * The margin takes a custom value of `12`, this value can be modified depending on what is specified in the
+ * style sheet.
+ */
+class QSliderLabeled : public QSlider
+{
+  public:
+    /**
+     * Constructor of the labeled QSlider.
+     *
+     * @param parent parent class
+     */
+    explicit QSliderLabeled(QWidget *parent = nullptr);
+
+    /**
+     * Sets the margin of the groove of the slider.
+     *
+     * @param value
+     */
+    void setGrooveMargin(int value);
+
+    /**
+     * Sets Maximum number of labels to display in the slider.
+     *
+     * @param value maximum number of labels.
+     */
+    void setMaxNumberOfLabels(int value);
+
+    /**
+     * Applies a custom style sheet that defines the width and height of the slider based on the orientation
+     * of the slider.
+     */
+    void applyStyleSheet();
+
+    /**
+     * Sets the maximum spread of the slider. This will represent the maximum height when slider is horizontal and
+     * the maximum width when it is vertical.
+     *
+     * @param value the slider spread.
+     */
+    void setSliderSpread(int value);
+
+  protected:
+    /**
+     * paint event used to draw the labels on the slider. This overrides the paint event, but it calls the original
+     * method before drawing the text.
+     *
+     * @param event paint event parameters
+     */
+    void paintEvent(QPaintEvent *event) override;
+
+    /**
+     * show event that overwrites the original QSlider show event to apply a custom style sheet before  showing the
+     * slider.
+     *
+     * @param event show event parameters
+     */
+    void showEvent(QShowEvent *event) override
+    {
+        QSlider::showEvent(event);
+        applyStyleSheet();
+    }
+
+    /**
+     * @brief Overrides the event() method from the parent class.
+     *
+     * This method is triggered when an event is received by the widget. It specifically handles the
+     * `QEvent::EnabledChange` event and calls the `updatePainterPen()` method to update the painter pen. It then calls
+     * the event() method of the parent class to handle any other events. Finally, it returns a boolean value indicating
+     * whether the event was handled.
+     *
+     * @param e The event object.
+     * @return True if the event was handled, false otherwise.
+     */
+    bool event(QEvent *e) override
+    {
+        if (e->type() == QEvent::EnabledChange)
+        {
+            updatePainterPen();
+        }
+        return QSlider::event(e);
+    }
+
+    /**
+     * Triggered when the mouse is moved over the labeled QSlider.
+     * It shows a tooltip with the corresponding value of the slider at the current mouse position using
+     * the `QToolTip` class. It then calls the `mouseMoveEvent()` method of the parent class to handle any other events.
+     *
+     * @param event A pointer to the `QMouseEvent` that contains information about the mouse move event.
+     */
+    void mouseMoveEvent(QMouseEvent *event) override;
+
+    /**
+     * Slider groove margin
+     */
+    int m_grooveMargin = 12;
+
+    /**
+     * Maximum number of labels to display
+     */
+    int m_maxNumberOfLabels = 8;
+
+    /**
+     * Size of the slider in pixels. Represents the maximum height when slider is horizontal and the maximum width when
+     * it is vertical.
+     */
+    int m_sliderSpread = 48;
+
+  private:
+    /**
+     * The color of the pen to use when drawing the text.
+     */
+    QColor m_penColor;
+
+    /**
+     * Updates the painter's pen color based on the enabled state of the QSliderLabeled widget.
+     * The pen color is set to a specific color if the widget is enabled, and to a different color if it is disabled.
+     */
+    void updatePainterPen();
+};
+
+#endif // XILENS_WIDGETS_H

--- a/tests/constantsTest.cpp
+++ b/tests/constantsTest.cpp
@@ -2,8 +2,10 @@
  * Author: Intelligent Medical Systems
  * License: see LICENSE.md file
  *******************************************************/
-#include "src/constants.h"
+
 #include <gtest/gtest.h>
+
+#include "src/constants.h"
 
 TEST(CameraMapperTest, ReturnsNonEmptyMapper)
 {


### PR DESCRIPTION
## Description

Adds custom `QSliderLabeled` widget to paint text indicating the values on each slider. All slider widgets are promoted to this new class in the UI. 

Summary of changes: 
* Adds a custom `QSlider` widget
* Removes sub folder input field from UI 
* Makes the base folder editable. 

## Related Issue

#29 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
