### PR TITLE
Static build option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           cd ..
           git clone https://github.com/Blosc/c-blosc2.git
           cd c-blosc2
-          git checkout v2.15.0
+          git checkout v2.15.1
           mkdir build
           cd build
           cmake -DCMAKE_INSTALL_PREFIX=/usr ..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Button to check if new cameras have been connected to the system.
 - LCD displayer to show frames per second that are stored to file while recording.
 - Custom QSliderLabeled widget to paint text marks on the slider.
+- Option to build xilens statically through cmake flag -DBUILD_STATIC.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(xilens VERSION 0.2.1)
 
 #################################
-##### compiler fiddling     #####
+##### compiler flags        #####
 #################################
 
 set (CMAKE_CXX_STANDARD 11)
@@ -34,6 +34,15 @@ add_definitions("-DCMAKE_SYSTEM=\"${CMAKE_SYSTEM}\"")
 add_definitions("-DCMAKE_SYSTEM_PROCESSOR=\"${CMAKE_SYSTEM_PROCESSOR}\"")
 
 #################################
+##### Build type            #####
+#################################
+option(BUILD_STATIC "Build xilens as a static app" OFF)
+if(BUILD_STATIC)
+    set(LIBRARY_TYPE STATIC)
+else()
+    set(LIBRARY_TYPE SHARED)
+endif()
+#################################
 ##### coverage fiddling     #####
 #################################
 option(ENABLE_COVERAGE "Enable coverage" OFF)
@@ -46,63 +55,20 @@ endif()
 #################################
 ##### set external packages #####
 #################################
-
-# platform specific settings
-
-cmake_host_system_information(RESULT UBUNTU_VERSION QUERY OS_VERSION)
-message("Found OS_VERSION: ${UBUNTU_VERSION} in Ubuntu")
-
-IF (UBUNTU_VERSION MATCHES "20.04")
-    # needed when using ubuntu 20
-    message([STATUS] "UBUNTU version found ${UBUNTU_VERSION}")
-    set(CMAKE_CXX_FLAGS "-luuid")
-    # boost
-    find_package(Boost REQUIRED python system thread timer chrono log filesystem)
-    include_directories(${Boost_INCLUDE_DIRS})
-ELSE ()
-    # boost
-    find_package(Boost REQUIRED system thread timer chrono log filesystem)
-    include_directories(${Boost_INCLUDE_DIRS})
-ENDIF ()
-
-IF (WIN32)
-    # if on windows: enter the path to your qt here.
-    set(CMAKE_PREFIX_PATH "C:\\Qt\\5.6\\msvc2015_64\\")
-
-    set(Boost_USE_STATIC_LIBS ON)
-    set(Boost_USE_MULTITHREADED ON)
-    set(Boost_USE_STATIC_RUNTIME OFF)
-
-    # for some reason windows doesn't find the shared libaries
-    set(LIBTYPE STATIC)
-
-    # because of boost asio
-    add_definitions(-DWIN32_LEAN_AND_MEAN)
-ELSE ()
-    set(LIBTYPE SHARED)
-    # apparently, the boost logging module needs the following.
-    # looks a little weird to me, shouldn't it be static?
-    # maybe, boost needs to be setup a little differently
-    add_definitions(-DBOOST_LOG_DYN_LINK)
-ENDIF ()
-
+# Boost
+find_package(Boost REQUIRED system thread timer chrono log filesystem)
+include_directories(${Boost_INCLUDE_DIRS})
 # BLOSC2
 find_package(Blosc2 2.15.0 CONFIG REQUIRED)
-
 # Message pack for metadata serialization
 find_package(msgpack REQUIRED)
-
-# qt
+# Qt
 find_package(Qt6 REQUIRED COMPONENTS Core Widgets Svg)
-
-# opencv
+# OpenCV
 set(OpenCV_STATIC ON)
 find_package(OpenCV REQUIRED COMPONENTS core imgproc highgui)
 include_directories(${OpenCV_INCLUDE_DIRS})
-# boost
-find_package(Boost REQUIRED python system thread timer chrono log filesystem)
-include_directories(${Boost_INCLUDE_DIRS})
-# ximea (camera)
+# XIMEA API
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 find_package(Ximea REQUIRED)
 include_directories(${Ximea_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,21 @@
+#-----------------------------------------------------------------------------------------------------------------------
+# Author: Intelligent Medical Systems
+# License: see LICENSE.md file
+#-----------------------------------------------------------------------------------------------------------------------
+# CMake project configuration
+#-----------------------------------------------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.5)
 project(xilens VERSION 0.2.1)
 
-#################################
-##### compiler flags        #####
-#################################
+#-----------------------------------------------------------------------------------------------------------------------
+# Language definitions
+#-----------------------------------------------------------------------------------------------------------------------
 
 set (CMAKE_CXX_STANDARD 11)
 
-#################################
-##### definitions           #####
-#################################
-
-# Add definitions for project build details
+#-----------------------------------------------------------------------------------------------------------------------
+# Package variable definitions
+#-----------------------------------------------------------------------------------------------------------------------
 # build date definitions
 string(TIMESTAMP CURRENT_DATETIME "%Y-%m-%d %H:%M:%S")
 add_definitions("-DBUILD_TIMESTAMP=\"${CURRENT_DATETIME}\"")
@@ -33,18 +37,19 @@ add_definitions("-DGIT_COMMIT=\"${GIT_COMMIT}\"")
 add_definitions("-DCMAKE_SYSTEM=\"${CMAKE_SYSTEM}\"")
 add_definitions("-DCMAKE_SYSTEM_PROCESSOR=\"${CMAKE_SYSTEM_PROCESSOR}\"")
 
-#################################
-##### Build type            #####
-#################################
+#-----------------------------------------------------------------------------------------------------------------------
+# Build type
+#-----------------------------------------------------------------------------------------------------------------------
 option(BUILD_STATIC "Build xilens as a static app" OFF)
 if(BUILD_STATIC)
     set(LIBRARY_TYPE STATIC)
 else()
     set(LIBRARY_TYPE SHARED)
 endif()
-#################################
-##### coverage fiddling     #####
-#################################
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test coverage fiddling
+#-----------------------------------------------------------------------------------------------------------------------
 option(ENABLE_COVERAGE "Enable coverage" OFF)
 if(ENABLE_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
@@ -52,14 +57,14 @@ if(ENABLE_COVERAGE)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 
-#################################
-##### set external packages #####
-#################################
+#-----------------------------------------------------------------------------------------------------------------------
+# Find external packages
+#-----------------------------------------------------------------------------------------------------------------------
 # Boost
 find_package(Boost REQUIRED system thread timer chrono log filesystem)
 include_directories(${Boost_INCLUDE_DIRS})
 # BLOSC2
-find_package(Blosc2 2.15.0 CONFIG REQUIRED)
+find_package(Blosc2 2.15.1 CONFIG REQUIRED)
 # Message pack for metadata serialization
 find_package(msgpack REQUIRED)
 # Qt
@@ -73,9 +78,9 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 find_package(Ximea REQUIRED)
 include_directories(${Ximea_INCLUDE_DIRS})
 
-######################
-##### xilensLib #####
-######################
+#-----------------------------------------------------------------------------------------------------------------------
+# XiLens library build
+#-----------------------------------------------------------------------------------------------------------------------
 set(XILENS_LIB_SRC src/mainwindow.cpp
         src/cameraInterface.cpp
         src/display.cpp
@@ -120,9 +125,9 @@ target_link_libraries(XILENS_LIB ${Boost_LIBRARIES})
 target_link_libraries(XILENS_LIB ${Ximea_LIBRARIES})
 target_link_libraries(XILENS_LIB Blosc2::blosc2_shared)
 
-###################
-##### XiLens #####
-###################
+#-----------------------------------------------------------------------------------------------------------------------
+# XiLens executable
+#-----------------------------------------------------------------------------------------------------------------------
 set(XILENS_BIN_SRC src/CLI.cpp src/CLI11.h)
 qt6_add_resources(XILENS_BIN_SRC resources/resources.qrc)
 qt6_add_resources(XILENS_BIN_SRC resources/theme_resources.qrc)
@@ -130,9 +135,9 @@ add_executable(xilens ${XILENS_BIN_SRC})
 target_link_libraries(xilens XILENS_LIB)
 file(COPY resources/XiLensCameraProperties.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-#################################
-##### Install and uninstall #####
-#################################
+#-----------------------------------------------------------------------------------------------------------------------
+# Install and uninstall
+#-----------------------------------------------------------------------------------------------------------------------
 # Setup the installation target
 install(TARGETS xilens XILENS_LIB
         RUNTIME DESTINATION bin
@@ -150,15 +155,13 @@ configure_file(
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
-#####################
-### Google Tests ####
-#####################
+#-----------------------------------------------------------------------------------------------------------------------
+# Google Tests
+#-----------------------------------------------------------------------------------------------------------------------
 find_package(GTest REQUIRED)
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
 enable_testing()
-
 add_executable(
         XILENS_TESTS
         tests/main.cpp
@@ -173,13 +176,12 @@ add_executable(
         ${XILENS_LIB_UI_MOC}
 )
 target_link_libraries(XILENS_TESTS GTest::gtest_main XILENS_LIB Blosc2::blosc2_shared)
-
 include(GoogleTest)
 gtest_discover_tests(XILENS_TESTS)
 
-#####################
-### DEB package  ####
-#####################
+#-----------------------------------------------------------------------------------------------------------------------
+# Packaging
+#-----------------------------------------------------------------------------------------------------------------------
 include(InstallRequiredSystemLibraries)
 file(STRINGS user-requirements.txt deps)
 string(REPLACE ";" ", " deps "${deps}")

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,6 +6,23 @@ Getting started
     In the future, you will need the ``CUDA`` library and drivers installed in your computer in order to use :code:`XiLens`.
     This is mainly because we are aiming at supporting the use of PyTorch models.
 
+Installing ``XiLens`` via ``apt``
+=================================
+You can install ``XiLens`` by downloading the corresponding ``.deb`` package from our `release page <https://github.com/IMSY-DKFZ/xilens/releases>`_.
+And then install it by doing:
+
+.. code::
+
+    sudo apt install ./xilens*.deb
+
+This will install ``XiLens`` and its dependencies that are available in ``apt``. ``XiLens`` still depends on ``BLOSC2``
+and XiAPI. Additional dependencies can be installed by running:
+
+.. code:: bash
+
+   chmod +x install_dependencies.sh
+   sudo ./install_dependencies.sh --user
+
 Build XiLens from source
 =========================
 
@@ -43,10 +60,14 @@ Finally, from the root directory of :code:`XiLens` do the following.
    ctest # to check that all tests pass
    sudo make install # installs the desktop app on the system and can be accessed from the app launcher
 
+.. note::
+
+    :code:`XiLens` can be built statically by adding a flag during configuration :code:`cmake -DBUILD_STATIC -DCMAKE_INSTALL_PREFIX=/usr ..`
+
 The application can be uninstalled from the system by doing :code:`sudo make uninstall` form the build directory
 
 Increase USB buffer limit
-=========================
+-------------------------
 .. important::
     After building ``XiLens``, you have to increase the buffer size for the
     data transfer via USB. This can be done every time you start your
@@ -88,11 +109,28 @@ Then you have to enable and start the service
 
 You should see that the service is marked as ``active``.
 
+Add user to :code:`pugdev` group
+--------------------------------
+After doing the following, you will have to log-out and log-in again for this tot ake effect.
+
+.. code:: bash
+
+   sudo usermod -aG plugdev $(whoami)
+
 Launching the application
 =========================
 After doing `sudo make install` from the build directory, the desktop app should be available through the app launcher
 of your system.
 Alternatively, you can run :code:`./xilens` from the build directory in a  terminal.
+
+Uninstalling :code:`XiLens`
+===========================
+If you installed `XiLens` with the `.deb` package, then you can uninstall it by doing :code:`sudo apt uninstall xilens`.
+If you build the app from source, you can uninstall it by doing the following from the directory where XiLens was built.
+
+.. code:: bash
+
+    sudo make uninstall
 
 Docker image
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,7 +26,8 @@ that can be used to record data from all the **XIMEA** camera families.
 
 Getting started
 ===============
-Installing dependencies, building :code:`XiLens` and how to use :code:`XiLens` is all introduced in the getting started section:
+Installing ``XiLens`` and its dependencies, building :code:`XiLens` from source and launching it, is all introduced in
+the getting started section:
 
 .. toctree::
     :maxdepth: 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -23,7 +23,7 @@ cd ..
 # install BLOSC2
 git clone https://github.com/Blosc/c-blosc2.git
 cd c-blosc2 || exit
-git checkout v2.15.0
+git checkout v2.15.1
 mkdir build
 cd build || exit
 cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \


### PR DESCRIPTION
## Description

Adds a flag for CMake to be able to build XiLens as a static library.
Summary of changes:
* Adds possibility to build library statically
* Bumps BLOSC2 version

## Related Issue

#31 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
