### PR TITLE
Fixes UI responsiveness hindered by temperature thread 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixes UI responsiveness hindered by temperature thread
 
 ## [0.2.1]
 

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -3,6 +3,8 @@
  * License: see LICENSE.md file
  *******************************************************/
 
+#include <boost/thread.hpp>
+
 #include "camera.h"
 
 #include "logger.h"
@@ -129,6 +131,7 @@ int RGBCamera::InitializeCamera()
 
 void XiSpecFamily::UpdateCameraTemperature()
 {
+    boost::lock_guard<boost::mutex> guard(this->mtx_);
     float chipTemp, houseTemp, houseBackSideTemp, sensorBoardTemp;
 
     this->m_apiWrapper->xiGetParamFloat(*m_cameraHandle, XI_PRM_CHIP_TEMP, &chipTemp);
@@ -143,6 +146,7 @@ void XiSpecFamily::UpdateCameraTemperature()
 
 void XiCFamily::UpdateCameraTemperature()
 {
+    boost::lock_guard<boost::mutex> guard(this->mtx_);
     float sensorBoardTemp;
     this->m_apiWrapper->xiGetParamFloat(*m_cameraHandle, XI_PRM_SENSOR_BOARD_TEMP, &sensorBoardTemp);
     this->m_cameraTemperature[SENSOR_BOARD_TEMP] = sensorBoardTemp;
@@ -150,6 +154,7 @@ void XiCFamily::UpdateCameraTemperature()
 
 void XiQFamily::UpdateCameraTemperature()
 {
+    boost::lock_guard<boost::mutex> guard(this->mtx_);
     float chipTemp, houseTemp, houseBackSideTemp, sensorBoardTemp;
     if (*m_cameraHandle != INVALID_HANDLE_VALUE)
     {

--- a/src/camera.h
+++ b/src/camera.h
@@ -6,10 +6,10 @@
 #ifndef XILENS_CAMERA_H
 #define XILENS_CAMERA_H
 
-#include <xiApi.h>
-
 #include <QMap>
 #include <QString>
+#include <boost/thread.hpp>
+#include <xiApi.h>
 
 #include "constants.h"
 #include "xiAPIWrapper.h"
@@ -21,6 +21,12 @@ class CameraFamily
      * Camera identifier used by API to communicate with camera
      */
     HANDLE *m_cameraHandle;
+
+    /**
+     * Mutex used to lock access to variables like the camera temperature, this allows updating temperature from
+     * multiple threads.
+     */
+    boost::mutex mtx_;
 
   public:
     explicit CameraFamily(HANDLE *handle) : m_cameraHandle(handle)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,7 +459,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
 void MainWindow::handleBaseFolderButtonClicked()
 {
     bool isValid = false;
-    this->StopTemperatureThread();
     while (!isValid)
     {
         QString baseFolderPath = QFileDialog::getExistingDirectory(
@@ -477,7 +476,6 @@ void MainWindow::handleBaseFolderButtonClicked()
             }
         }
     }
-    this->StartTemperatureThread();
 }
 
 void MainWindow::WriteLogHeader()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -318,6 +318,7 @@ void MainWindow::HandleTemperatureTimer(const boost::system::error_code &error)
         return;
     }
 
+    m_cameraInterface.m_camera->family->get()->UpdateCameraTemperature();
     this->DisplayCameraTemperature();
 
     // Reset timer
@@ -328,6 +329,8 @@ void MainWindow::HandleTemperatureTimer(const boost::system::error_code &error)
 
 void MainWindow::StartTemperatureThread()
 {
+    // Initial temperature update to ensure that it is populated before recordings start.
+    m_cameraInterface.m_camera->family->get()->UpdateCameraTemperature();
     if (m_temperatureThread.joinable())
     {
         StopTemperatureThread();


### PR DESCRIPTION
## Description
Fixes the slow response of `Save Folder` button by removing the calls to start and stop temperature threads on click. Such calls to temperature threads are no longer needed since the temperature is stored in the metadata of the image files instead of an extra log file.
Additionally, a call to update the camera temperature member variable of each camera family is done when the temperature thread is started such that the variable is populated before any recording starts. 

## Related Issue

#34 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
