### PR TITLE
add viewer tab for recorded arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Adds image viewer tab to open recorded .b2nd files and scroll over images.
+- Adds missing camera models to JSON file.
 
 ### Changed
 
--
+- All displaying operations run from a thread, and only calls the main thread when the process images are to be displayed.
+- Restructures UI for a more clear use and structures controls inside a toolbox.
+- Limits frequency at which images are displayed to avoid locking the UI. Images are still recorded at full speed.
 
 ### Removed
 

--- a/resources/XiLensCameraProperties.json
+++ b/resources/XiLensCameraProperties.json
@@ -389,6 +389,12 @@
     "mosaicWidth": 0,
     "mosaicHeight": 0
   },
+  "MQ042CG-CM": {
+    "cameraType": "rgb",
+    "cameraFamily": "xiQ",
+    "mosaicWidth": 0,
+    "mosaicHeight": 0
+  },
   "MQ042CG-CM-S7": {
     "cameraType": "rgb",
     "cameraFamily": "xiQ",

--- a/resources/dark_amber.css
+++ b/resources/dark_amber.css
@@ -814,15 +814,22 @@ QMenuBar::item:pressed {
 
 QToolBox::tab {
   background-color: #232629;
-  color: #ffffff;
+  color: #ffd740;
   text-transform: uppercase;
   border-radius: 4px;
   padding-left: 15px;
+  font-weight: bold;
 }
 
 QToolBox::tab:selected,
 QToolBox::tab:hover {
   background-color: rgba(255, 215, 64, 0.2);
+}
+
+QToolBox::tab:disabled {
+  color: rgba(79, 91, 98, 0.75);
+  background-color: rgba(35, 38, 41, 0.3);
+  border-color:  #4f5b62;
 }
 
 /*  ------------------------------------------------------------------------  */

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -3,10 +3,15 @@
  * License: see LICENSE.md file
  *******************************************************/
 #include <QApplication>
+#include <QMetaType>
+#include <opencv2/core.hpp>
 
 #include "CLI11.h"
 #include "mainwindow.h"
 #include "util.h"
+
+Q_DECLARE_METATYPE(cv::Mat)
+Q_DECLARE_METATYPE(cv::Mat &)
 
 /**
  * @brief Application entry point and command line interface setup.
@@ -42,6 +47,8 @@ int main(int argc, char **argv)
 
     // instantiate application
     QApplication a(argc, argv);
+    qRegisterMetaType<cv::Mat>("cv::Mat");
+    qRegisterMetaType<cv::Mat &>("cv::Mat&");
     QFile themeFile(":/resources/dark_amber.css");
     if (themeFile.open(QFile::ReadOnly | QFile::Text))
     {

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -3,15 +3,10 @@
  * License: see LICENSE.md file
  *******************************************************/
 #include <QApplication>
-#include <QMetaType>
-#include <opencv2/core.hpp>
 
 #include "CLI11.h"
 #include "mainwindow.h"
 #include "util.h"
-
-Q_DECLARE_METATYPE(cv::Mat)
-Q_DECLARE_METATYPE(cv::Mat &)
 
 /**
  * @brief Application entry point and command line interface setup.
@@ -47,8 +42,6 @@ int main(int argc, char **argv)
 
     // instantiate application
     QApplication a(argc, argv);
-    qRegisterMetaType<cv::Mat>("cv::Mat");
-    qRegisterMetaType<cv::Mat &>("cv::Mat&");
     QFile themeFile(":/resources/dark_amber.css");
     if (themeFile.open(QFile::ReadOnly | QFile::Text))
     {

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -14,7 +14,7 @@ void CameraFamily::UpdateCameraTemperature()
 {
 }
 
-QMap<QString, float> CameraFamily::getCameraTemperature()
+QMap<QString, float> CameraFamily::GetCameraTemperature()
 {
     return this->m_cameraTemperature;
 }
@@ -131,7 +131,7 @@ int RGBCamera::InitializeCamera()
 
 void XiSpecFamily::UpdateCameraTemperature()
 {
-    boost::lock_guard<boost::mutex> guard(this->mtx_);
+    boost::lock_guard<boost::mutex> guard(this->m_mutexCameraTemperature);
     float chipTemp, houseTemp, houseBackSideTemp, sensorBoardTemp;
 
     this->m_apiWrapper->xiGetParamFloat(*m_cameraHandle, XI_PRM_CHIP_TEMP, &chipTemp);
@@ -146,7 +146,7 @@ void XiSpecFamily::UpdateCameraTemperature()
 
 void XiCFamily::UpdateCameraTemperature()
 {
-    boost::lock_guard<boost::mutex> guard(this->mtx_);
+    boost::lock_guard<boost::mutex> guard(this->m_mutexCameraTemperature);
     float sensorBoardTemp;
     this->m_apiWrapper->xiGetParamFloat(*m_cameraHandle, XI_PRM_SENSOR_BOARD_TEMP, &sensorBoardTemp);
     this->m_cameraTemperature[SENSOR_BOARD_TEMP] = sensorBoardTemp;
@@ -154,7 +154,7 @@ void XiCFamily::UpdateCameraTemperature()
 
 void XiQFamily::UpdateCameraTemperature()
 {
-    boost::lock_guard<boost::mutex> guard(this->mtx_);
+    boost::lock_guard<boost::mutex> guard(this->m_mutexCameraTemperature);
     float chipTemp, houseTemp, houseBackSideTemp, sensorBoardTemp;
     if (*m_cameraHandle != INVALID_HANDLE_VALUE)
     {

--- a/src/camera.h
+++ b/src/camera.h
@@ -26,7 +26,7 @@ class CameraFamily
      * Mutex used to lock access to variables like the camera temperature, this allows updating temperature from
      * multiple threads.
      */
-    boost::mutex mtx_;
+    boost::mutex m_mutexCameraTemperature;
 
   public:
     explicit CameraFamily(HANDLE *handle) : m_cameraHandle(handle)
@@ -90,7 +90,7 @@ class CameraFamily
     /*
      * Queries camera temperature
      */
-    QMap<QString, float> getCameraTemperature();
+    QMap<QString, float> GetCameraTemperature();
 };
 
 /**
@@ -212,7 +212,7 @@ class Camera
      * @param family family of the camera to be constructed
      * @param handle camera handle used for all interactions with it
      */
-    Camera(std::unique_ptr<CameraFamily> *family, HANDLE *handle) : family(family), m_cameraHandle(handle)
+    Camera(std::unique_ptr<CameraFamily> *family, HANDLE *handle) : m_cameraFamily(family), m_cameraHandle(handle)
     {
     }
 
@@ -224,7 +224,7 @@ class Camera
     /**
      * Unique pointer to camera family
      */
-    std::unique_ptr<CameraFamily> *family;
+    std::unique_ptr<CameraFamily> *m_cameraFamily;
 
     /**
      * initializes camera by setting parameters such as framerate, binning mode,

--- a/src/cameraInterface.cpp
+++ b/src/cameraInterface.cpp
@@ -93,7 +93,7 @@ int CameraInterface::OpenDevice(DWORD cameraDeviceID)
     stat = this->m_apiWrapper->xiOpenDevice(cameraDeviceID, &m_cameraHandle);
     HandleResult(stat, "xiOepnDevice");
 
-    this->setCamera(m_cameraType, m_cameraFamilyName);
+    this->SetCamera(m_cameraType, m_cameraFamilyName);
 
     stat = this->m_camera->InitializeCamera();
     if (stat != XI_OK)
@@ -169,7 +169,7 @@ CameraInterface::~CameraInterface()
     }
 }
 
-void CameraInterface::setCamera(QString cameraType, QString cameraFamily)
+void CameraInterface::SetCamera(QString cameraType, QString cameraFamily)
 {
     // instantiate camera type
     if (cameraType == CAMERA_TYPE_SPECTRAL)

--- a/src/cameraInterface.h
+++ b/src/cameraInterface.h
@@ -54,7 +54,7 @@ class CameraInterface : public QObject
      */
     ~CameraInterface();
 
-    void setCamera(QString cameraType, QString cameraFamily);
+    void SetCamera(QString cameraType, QString cameraFamily);
 
     /**
      * @brief Initializes a device with the specified camera ID.

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,12 +1,10 @@
 #include "display.h"
 
-Displayer::Displayer()
+Displayer::Displayer(QObject *parent) : QObject(parent)
 {
 }
 
-Displayer::~Displayer()
-{
-}
+Displayer::~Displayer() = default;
 
 void Displayer::StopDisplayer()
 {
@@ -16,4 +14,5 @@ void Displayer::StopDisplayer()
 void Displayer::StartDisplayer()
 {
     this->m_stop = false;
+    this->m_displayCondition.notify_one();
 }

--- a/src/display.h
+++ b/src/display.h
@@ -9,15 +9,16 @@
 
 #include <QObject>
 #include <QString>
+#include <boost/thread.hpp>
 
 class Displayer : public QObject
 {
     Q_OBJECT
 
   public:
-    explicit Displayer();
+    explicit Displayer(QObject *parent = nullptr);
 
-    ~Displayer();
+    ~Displayer() override;
 
     QString m_cameraType;
 
@@ -34,10 +35,22 @@ class Displayer : public QObject
     void StartDisplayer();
 
   protected:
+    /**
+     * Indicate that process should stop displaying images.
+     */
     bool m_stop = false;
+
+    /**
+     * condition variable used to wait until a new image is available to be processed.
+     */
+    boost::condition_variable m_displayCondition;
 
   public slots:
 
+    /**
+     * Qt slot in charge of displaying images.
+     * @param image
+     */
     virtual void Display(XI_IMG &image) = 0;
 };
 

--- a/src/display.h
+++ b/src/display.h
@@ -5,11 +5,11 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
-#include <xiApi.h>
-
 #include <QObject>
 #include <QString>
 #include <boost/thread.hpp>
+#include <opencv2/core.hpp>
+#include <xiApi.h>
 
 class Displayer : public QObject
 {
@@ -33,6 +33,22 @@ class Displayer : public QObject
      * Allows to start or continue displaying images
      */
     void StartDisplayer();
+
+  signals:
+    /**
+     * Qt signal emitted when an RGB image is ready to be displayed in the UI.
+     */
+    void ImageReadyToUpdateRGB(cv::Mat &);
+
+    /**
+     * Qt signal emitted when a raw image is ready to be displayed in the UI.
+     */
+    void ImageReadyToUpdateRaw(cv::Mat &);
+
+    /**
+     * Qt signal emitted when a new image is ready to compute the saturation percentage for the display.
+     */
+    void SaturationPercentageImageReady(cv::Mat &);
 
   protected:
     /**

--- a/src/displayFunctional.cpp
+++ b/src/displayFunctional.cpp
@@ -266,11 +266,9 @@ void DisplayerFunctional::ProcessImage(XI_IMG &image)
         PrepareBGRImage(bgrImage, static_cast<int>(m_mainWindow->GetBGRNorm()));
     }
     // Update saturation display and display images through the main thread
-    QMetaObject::invokeMethod(m_mainWindow, "UpdateSaturationPercentageLCDDisplays", Qt::QueuedConnection,
-                              Q_ARG(cv::Mat &, rawImage));
-    QMetaObject::invokeMethod(m_mainWindow, "UpdateRGBImage", Qt::QueuedConnection, Q_ARG(cv::Mat &, bgrImage));
-    QMetaObject::invokeMethod(m_mainWindow, "UpdateRawImage", Qt::QueuedConnection,
-                              Q_ARG(cv::Mat &, rawImageToDisplay));
+    emit ImageReadyToUpdateRGB(bgrImage);
+    emit ImageReadyToUpdateRaw(rawImageToDisplay);
+    emit SaturationPercentageImageReady(rawImage);
 }
 
 void DisplayerFunctional::GetBGRImage(cv::Mat &image, cv::Mat &bgr_image)

--- a/src/displayFunctional.cpp
+++ b/src/displayFunctional.cpp
@@ -54,10 +54,10 @@ void DisplayerFunctional::NormalizeBGRImage(cv::Mat &bgr_image)
     std::vector<cv::Mat> lab_planes(3);
     cv::split(lab_image, lab_planes);
 
-    // apply clahe to the L channel and save it in lab_planes
+    // apply m_clahe to the L channel and save it in lab_planes
     cv::Mat dst;
-    this->clahe->setClipLimit(m_mainWindow->GetBGRNorm());
-    this->clahe->apply(lab_planes[0], dst);
+    this->m_clahe->setClipLimit(m_mainWindow->GetBGRNorm());
+    this->m_clahe->apply(lab_planes[0], dst);
     dst.copyTo(lab_planes[0]);
 
     // merge color planes back to bgr_image
@@ -74,7 +74,7 @@ void DisplayerFunctional::PrepareRawImage(cv::Mat &raw_image, bool equalize_hist
     cv::LUT(mask, m_lut, mask);
     if (equalize_hist)
     {
-        this->clahe->apply(raw_image, raw_image);
+        this->m_clahe->apply(raw_image, raw_image);
     }
     cvtColor(raw_image, raw_image, cv::COLOR_GRAY2RGB);
 
@@ -151,7 +151,7 @@ void DisplayerFunctional::Display(XI_IMG &image)
         // by skipping every 100th frame
         if (selected_display % 100 > 0)
         {
-            boost::lock_guard<boost::mutex> guard(mtx_);
+            boost::lock_guard<boost::mutex> guard(m_mutexImageDisplay);
 
             cv::Mat currentImage(image.height, image.width, CV_16UC1, image.bp);
             cv::Mat rawImage;
@@ -222,7 +222,7 @@ void DisplayerFunctional::Display(XI_IMG &image)
 void DisplayerFunctional::GetBGRImage(cv::Mat &image, cv::Mat &bgr_image)
 {
     std::vector<cv::Mat> channels;
-    for (int i : m_bgr_channels)
+    for (int i : m_BGRChannels)
     {
         cv::Mat band_image = InitializeBandImage(image);
         this->GetBand(image, band_image, i);

--- a/src/displayFunctional.h
+++ b/src/displayFunctional.h
@@ -110,6 +110,11 @@ class DisplayerFunctional : public Displayer
 
   private:
     /**
+     * Thread where the image processing before displaying them should run.
+     */
+    boost::thread m_displayThread;
+
+    /**
      * Indicates if an image has to be displayed.
      */
     bool m_hasPendingImage = false;
@@ -156,6 +161,12 @@ class DisplayerFunctional : public Displayer
      * @param image XIMEA image to be processed and displayed through the main UI.
      */
     void ProcessImage(XI_IMG &image);
+
+    /**
+     * Waits for an image to be available for processing and calls `ProcessImage` once an image is available.
+     * This method itself is triggered when the display timer runs out.
+     */
+    [[noreturn]] void ProcessImageOnThread();
 
     /**
      * @brief prepares raw image from XIMEA camera to be displayed, it does

--- a/src/displayFunctional.h
+++ b/src/displayFunctional.h
@@ -21,20 +21,6 @@
 class MainWindow;
 
 /**
- * @brief Enumerates the types of display images.
- *
- * The DisplayImageType enumerator represents the different types of display
- * images. It provides symbolic names for the supported image types.
- */
-enum DisplayImageType
-{
-    RAW = 0,
-    RGB = 1,
-    VHB = 2,
-    OXY = 3
-};
-
-/**
  * @brief The DisplayerFunctional class is responsible for displaying images.
  *
  * It inherits from the Displayer class and uses the MainWindow class for
@@ -120,7 +106,7 @@ class DisplayerFunctional : public Displayer
      * Vector with channel numbers that can be used to construct an approximate
      * RGB image
      */
-    std::vector<int> m_bgr_channels = {11, 15, 3};
+    std::vector<int> m_BGRChannels = {11, 15, 3};
 
     /**
      * Scaling factor used to convert image from 10bit to 8bit
@@ -128,21 +114,14 @@ class DisplayerFunctional : public Displayer
     int m_scaling_factor = 4;
 
     /**
-     * Dummy method, not yet implemented
-     *
-     * @param image Image to be run through the network
-     */
-    void RunNetwork(XI_IMG &image);
-
-    /**
      * explicit mutex declaration
      */
-    boost::mutex mtx_;
+    boost::mutex m_mutexImageDisplay;
 
     /**
      * Class to do histogram normalization with CLAHE
      */
-    cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+    cv::Ptr<cv::CLAHE> m_clahe = cv::createCLAHE();
 
     /**
      * @brief prepares raw image from XIMEA camera to be displayed, it does
@@ -218,4 +197,4 @@ class DisplayerFunctional : public Displayer
  */
 void PrepareBGRImage(cv::Mat &bgr_image, int bgr_norm);
 
-#endif // DISPLAY_H
+#endif // DISPLAYFUNCTIONAL_H

--- a/src/imageContainer.cpp
+++ b/src/imageContainer.cpp
@@ -51,7 +51,7 @@ void ImageContainer::PollImage(HANDLE *cameraHandle, int pollingRate)
     while (m_PollImage)
     {
         {
-            boost::lock_guard<boost::mutex> guard(mtx_);
+            boost::lock_guard<boost::mutex> guard(m_mutexImageAccess);
             boost::this_thread::interruption_point();
             if (cameraHandle != INVALID_HANDLE_VALUE)
             {
@@ -74,7 +74,7 @@ void ImageContainer::PollImage(HANDLE *cameraHandle, int pollingRate)
                 lastImageId = m_Image.acq_nframe;
             }
         }
-        wait(pollingRate);
+        WaitMilliseconds(pollingRate);
     }
 }
 
@@ -90,6 +90,6 @@ void ImageContainer::StartPolling()
 
 XI_IMG ImageContainer::GetCurrentImage()
 {
-    boost::lock_guard<boost::mutex> guard(mtx_);
+    boost::lock_guard<boost::mutex> guard(m_mutexImageAccess);
     return m_Image;
 }

--- a/src/imageContainer.h
+++ b/src/imageContainer.h
@@ -114,7 +114,7 @@ class ImageContainer : public QObject
     /**
      * mutex declaration used to lock guard the current image in the container
      */
-    boost::mutex mtx_;
+    boost::mutex m_mutexImageAccess;
 };
 
 #endif // IMAGE_CONTAINER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1115,6 +1115,10 @@ void MainWindow::HandleCameraListComboBoxCurrentIndexChanged(int index)
 
 void MainWindow::HandleReloadCamerasPushButtonClicked()
 {
+    // set button style as pressed down, and process event loop before continuing
+    ui->reloadCamerasPushButton->setDown(true);
+    QCoreApplication::processEvents();
+
     QStringList cameraList = m_cameraInterface.GetAvailableCameraIdentifiers();
     // Only add new camera models
     for (const QString &camera : cameraList)
@@ -1138,6 +1142,9 @@ void MainWindow::HandleReloadCamerasPushButtonClicked()
             ui->cameraListComboBox->removeItem(i);
         }
     }
+
+    // restore button style
+    ui->reloadCamerasPushButton->setDown(false);
 }
 
 void MainWindow::UpdateSaturationPercentageLCDDisplays(cv::Mat &image) const

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -48,7 +48,6 @@ MainWindow::MainWindow(QWidget *parent, const std::shared_ptr<XiAPIWrapper> &xiA
     m_imageContainer.Initialize(this->m_xiAPIWrapper);
     m_updateFPSDisplayTimer = new QTimer(this);
     ui->setupUi(this);
-    this->SetUpConnections();
     this->SetUpCustomUiComponents();
 
     // Initialize BLOSC2
@@ -74,7 +73,7 @@ MainWindow::MainWindow(QWidget *parent, const std::shared_ptr<XiAPIWrapper> &xiA
     expSpinBox->setValue(expSlider->value());
 
     LOG_XILENS(info) << "test mode (recording everything to same file) is set to: " << m_testMode << "\n";
-
+    this->SetUpConnections();
     EnableUi(false);
 }
 
@@ -128,6 +127,12 @@ void MainWindow::SetUpConnections()
                                               &MainWindow::HandleViewerFileLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerFileLineEdit, &QLineEdit::returnPressed, this,
                                               &MainWindow::HandleViewerFileLineEditReturnPressed));
+    HANDLE_CONNECTION_RESULT(
+        QObject::connect(m_display, &Displayer::ImageReadyToUpdateRGB, this, &MainWindow::UpdateRGBImage));
+    HANDLE_CONNECTION_RESULT(
+        QObject::connect(m_display, &Displayer::ImageReadyToUpdateRaw, this, &MainWindow::UpdateRawImage));
+    HANDLE_CONNECTION_RESULT(QObject::connect(m_display, &Displayer::SaturationPercentageImageReady, this,
+                                              &MainWindow::UpdateSaturationPercentageLCDDisplays));
 }
 
 void MainWindow::HandleConnectionResult(bool status, const char *file, int line, const char *func)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -60,7 +60,7 @@ MainWindow::MainWindow(QWidget *parent, const std::shared_ptr<XiAPIWrapper> &xiA
 
     // populate available cameras
     ui->cameraListComboBox->addItem("select camera to enable UI...");
-    this->handleReloadCamerasPushButtonClicked();
+    this->HandleReloadCamerasPushButtonClicked();
     ui->cameraListComboBox->setCurrentIndex(0);
 
     // set the base folder loc
@@ -86,59 +86,59 @@ MainWindow::MainWindow(QWidget *parent, const std::shared_ptr<XiAPIWrapper> &xiA
 void MainWindow::SetUpConnections()
 {
     HANDLE_CONNECTION_RESULT(
-        QObject::connect(ui->snapshotButton, &QPushButton::clicked, this, &MainWindow::handleSnapshotButtonClicked));
+        QObject::connect(ui->snapshotButton, &QPushButton::clicked, this, &MainWindow::HandleSnapshotButtonClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->exposureSlider, &QSlider::valueChanged, this,
-                                              &MainWindow::handleExposureSliderValueChanged));
+                                              &MainWindow::HandleExposureSliderValueChanged));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerImageSlider, &QSlider::valueChanged, this,
-                                              &MainWindow::handleViewerImageSliderValueChanged));
+                                              &MainWindow::HandleViewerImageSliderValueChanged));
     HANDLE_CONNECTION_RESULT(
-        QObject::connect(ui->recordButton, &QPushButton::clicked, this, &MainWindow::handleRecordButtonClicked));
+        QObject::connect(ui->recordButton, &QPushButton::clicked, this, &MainWindow::HandleRecordButtonClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderButton, &QPushButton::clicked, this,
-                                              &MainWindow::handleBaseFolderButtonClicked));
+                                              &MainWindow::HandleBaseFolderButtonClicked));
     HANDLE_CONNECTION_RESULT(
         QObject::connect(this, &MainWindow::ViewerImageProcessingComplete, this, &MainWindow::UpdateRawViewerImage));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerFileButton, &QPushButton::clicked, this,
-                                              &MainWindow::handleViewerFileButtonClicked));
+                                              &MainWindow::HandleViewerFileButtonClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->exposureLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleExposureLineEditTextEdited));
+                                              &MainWindow::HandleExposureLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->exposureLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleExposureLineEditReturnPressed));
+                                              &MainWindow::HandleExposureLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleFilePrefixLineEditTextEdited));
+                                              &MainWindow::HandleFilePrefixLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleFilePrefixLineEditReturnPressed));
+                                              &MainWindow::HandleFilePrefixLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->autoexposureCheckbox, &QCheckBox::clicked, this,
-                                              &MainWindow::handleAutoexposureCheckboxClicked));
+                                              &MainWindow::HandleAutoexposureCheckboxClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->whiteBalanceButton, &QPushButton::clicked, this,
-                                              &MainWindow::handleWhiteBalanceButtonClicked));
+                                              &MainWindow::HandleWhiteBalanceButtonClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->darkCorrectionButton, &QPushButton::clicked, this,
-                                              &MainWindow::handleDarkCorrectionButtonClicked));
+                                              &MainWindow::HandleDarkCorrectionButtonClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->logTextLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleLogTextLineEditTextEdited));
+                                              &MainWindow::HandleLogTextLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->logTextLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleLogTextLineEditReturnPressed));
+                                              &MainWindow::HandleLogTextLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->skipFramesSpinBox, &QSpinBox::valueChanged, this,
-                                              &MainWindow::handleSkipFramesSpinBoxValueChanged));
+                                              &MainWindow::HandleSkipFramesSpinBoxValueChanged));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->cameraListComboBox, &QComboBox::currentIndexChanged, this,
-                                              &MainWindow::handleCameraListComboBoxCurrentIndexChanged));
+                                              &MainWindow::HandleCameraListComboBoxCurrentIndexChanged));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->reloadCamerasPushButton, &QPushButton::clicked, this,
-                                              &MainWindow::handleReloadCamerasPushButtonClicked));
+                                              &MainWindow::HandleReloadCamerasPushButtonClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixExtrasLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleFilePrefixExtrasLineEditTextEdited));
+                                              &MainWindow::HandleFilePrefixExtrasLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixExtrasLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleFilePrefixExtrasLineEditReturnPressed));
+                                              &MainWindow::HandleFilePrefixExtrasLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleBaseFolderLineEditReturnPressed));
+                                              &MainWindow::HandleBaseFolderLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderExtrasLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleSubFolderExtrasLineEditTextEdited));
+                                              &MainWindow::HandleSubFolderExtrasLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleBaseFolderLineEditTextEdited));
+                                              &MainWindow::HandleBaseFolderLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerFileLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::handleViewerFileLineEditTextEdited));
+                                              &MainWindow::HandleViewerFileLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderExtrasLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleSubFolderExtrasLineEditReturnPressed));
+                                              &MainWindow::HandleSubFolderExtrasLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerFileLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::handleViewerFileLineEditReturnPressed));
+                                              &MainWindow::HandleViewerFileLineEditReturnPressed));
 }
 
 void MainWindow::HandleConnectionResult(bool status, const char *file, int line, const char *func)
@@ -295,9 +295,9 @@ void MainWindow::RecordSnapshots()
     {
         int exp_time = m_cameraInterface.m_camera->GetExposureMs();
         int waitTime = 2 * exp_time;
-        wait(waitTime);
+        WaitMilliseconds(waitTime);
         image = m_imageContainer.GetCurrentImage();
-        snapshotsFile.write(image, GetCameraTemperature());
+        snapshotsFile.WriteImageData(image, GetCameraTemperature());
         int progress = static_cast<int>((static_cast<float>(i + 1) / static_cast<float>(nr_images)) * 100);
         QMetaObject::invokeMethod(ui->progressBar, "setValue", Qt::QueuedConnection, Q_ARG(int, progress));
     }
@@ -309,21 +309,21 @@ void MainWindow::RecordSnapshots()
     QMetaObject::invokeMethod(ui->subFolderExtrasLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
 }
 
-void MainWindow::handleSnapshotButtonClicked()
+void MainWindow::HandleSnapshotButtonClicked()
 {
     m_snapshotsThread = boost::thread(&MainWindow::RecordSnapshots, this);
 }
 
 QMap<QString, float> MainWindow::GetCameraTemperature() const
 {
-    m_cameraInterface.m_camera->family->get()->UpdateCameraTemperature();
-    auto cameraTemperature = m_cameraInterface.m_camera->family->get()->m_cameraTemperature;
+    m_cameraInterface.m_camera->m_cameraFamily->get()->UpdateCameraTemperature();
+    auto cameraTemperature = m_cameraInterface.m_camera->m_cameraFamily->get()->m_cameraTemperature;
     return cameraTemperature;
 }
 
 void MainWindow::DisplayCameraTemperature()
 {
-    double temp = m_cameraInterface.m_camera->family->get()->m_cameraTemperature.value(SENSOR_BOARD_TEMP);
+    double temp = m_cameraInterface.m_camera->m_cameraFamily->get()->m_cameraTemperature.value(SENSOR_BOARD_TEMP);
     QMetaObject::invokeMethod(ui->temperatureLCDNumber, "display", Qt::QueuedConnection, Q_ARG(double, temp));
 }
 
@@ -344,7 +344,7 @@ void MainWindow::HandleTemperatureTimer(const boost::system::error_code &error)
         return;
     }
 
-    m_cameraInterface.m_camera->family->get()->UpdateCameraTemperature();
+    m_cameraInterface.m_camera->m_cameraFamily->get()->UpdateCameraTemperature();
     this->DisplayCameraTemperature();
 
     // Reset timer
@@ -356,7 +356,7 @@ void MainWindow::HandleTemperatureTimer(const boost::system::error_code &error)
 void MainWindow::StartTemperatureThread()
 {
     // Initial temperature update to ensure that it is populated before recordings start.
-    m_cameraInterface.m_camera->family->get()->UpdateCameraTemperature();
+    m_cameraInterface.m_camera->m_cameraFamily->get()->UpdateCameraTemperature();
     if (m_temperatureThread.joinable())
     {
         StopTemperatureThread();
@@ -401,13 +401,13 @@ void MainWindow::StopReferenceRecordingThread()
     }
 }
 
-void MainWindow::handleExposureSliderValueChanged(int value)
+void MainWindow::HandleExposureSliderValueChanged(int value)
 {
     m_cameraInterface.m_camera->SetExposureMs(value);
     UpdateExposure();
 }
 
-void MainWindow::handleViewerImageSliderValueChanged(int value)
+void MainWindow::HandleViewerImageSliderValueChanged(int value)
 {
     {
         boost::lock_guard<boost::mutex> lock(m_mutexImageViewer);
@@ -416,7 +416,7 @@ void MainWindow::handleViewerImageSliderValueChanged(int value)
     m_viewerQueueCondition.notify_one();
 }
 
-void MainWindow::processViewerImageSliderValueChanged(int value)
+void MainWindow::ProcessViewerImageSliderValueChanged(int value)
 {
     std::array<int64_t, B2ND_MAX_DIM> slice_start = {0};
     std::array<int64_t, B2ND_MAX_DIM> slice_stop = {0};
@@ -470,7 +470,7 @@ void MainWindow::ViewerWorkerThreadFunc()
 
         if (value != -1)
         {
-            processViewerImageSliderValueChanged(value);
+            ProcessViewerImageSliderValueChanged(value);
         }
     }
 }
@@ -490,7 +490,7 @@ void MainWindow::UpdateExposure()
     ui->exposureSlider->setValue(exp_ms);
 }
 
-void MainWindow::handleRecordButtonClicked(bool clicked)
+void MainWindow::HandleRecordButtonClicked(bool clicked)
 {
     static QString original_colour;
     static QString original_button_text;
@@ -547,13 +547,13 @@ void MainWindow::closeEvent(QCloseEvent *event)
 {
     if (this->ui->recordButton->isChecked())
     {
-        handleRecordButtonClicked(false);
+        HandleRecordButtonClicked(false);
     }
     this->StopPollingThread();
     QMainWindow::closeEvent(event);
 }
 
-void MainWindow::handleBaseFolderButtonClicked()
+void MainWindow::HandleBaseFolderButtonClicked()
 {
     bool isValid = false;
     while (!isValid)
@@ -575,7 +575,7 @@ void MainWindow::handleBaseFolderButtonClicked()
     }
 }
 
-void MainWindow::handleViewerFileButtonClicked()
+void MainWindow::HandleViewerFileButtonClicked()
 {
     QString filePath = QFileDialog::getOpenFileName(this, tr("Open File"), "", tr("NDArrays (*.b2nd)"));
     if (QFile(filePath).exists())
@@ -585,7 +585,7 @@ void MainWindow::handleViewerFileButtonClicked()
             m_viewerFilePath = filePath;
             ui->viewerFileLineEdit->clear();
             ui->viewerFileLineEdit->insert(filePath);
-            this->handleViewerFileLineEditReturnPressed();
+            this->HandleViewerFileLineEditReturnPressed();
             OpenFileInViewer(m_viewerFilePath);
         }
     }
@@ -598,7 +598,7 @@ void MainWindow::OpenFileInViewer(const QString &filePath)
     this->ui->viewerImageSlider->setEnabled(true);
     auto n_images = static_cast<int>(this->m_viewerNDArray->shape[0] - 1);
     this->ui->viewerImageSlider->setMaximum(n_images);
-    this->handleViewerImageSliderValueChanged(this->ui->viewerImageSlider->value());
+    this->HandleViewerImageSliderValueChanged(this->ui->viewerImageSlider->value());
 }
 
 void MainWindow::WriteLogHeader()
@@ -676,7 +676,7 @@ void MainWindow::RecordImage(bool ignoreSkipping)
     {
         try
         {
-            this->m_imageContainer.m_imageFile->write(image, GetCameraTemperature());
+            this->m_imageContainer.m_imageFile->WriteImageData(image, GetCameraTemperature());
             m_recordedCount++;
         }
         catch (const std::runtime_error &e)
@@ -715,7 +715,7 @@ void MainWindow::DisplayRecordCount()
                               Q_ARG(int, static_cast<int>(m_recordedCount.load())));
 }
 
-void MainWindow::updateTimer()
+void MainWindow::UpdateTimer()
 {
     m_elapsedTime = static_cast<double>(m_elapsedTimer.elapsed()) / 1000.0;
     int totalSeconds = static_cast<int>(m_elapsedTime);
@@ -738,7 +738,7 @@ void MainWindow::updateTimer()
     ui->timerLCDNumber->display(m_elapsedTimeText);
 }
 
-void MainWindow::stopTimer()
+void MainWindow::StopTimer()
 {
     ui->timerLCDNumber->display(0);
 }
@@ -763,7 +763,7 @@ void MainWindow::StartRecording()
     HANDLE_CONNECTION_RESULT(
         QObject::connect(&(this->m_imageContainer), &ImageContainer::NewImage, this, &MainWindow::CountImages));
     HANDLE_CONNECTION_RESULT(
-        QObject::connect(&(this->m_imageContainer), &ImageContainer::NewImage, this, &MainWindow::updateTimer));
+        QObject::connect(&(this->m_imageContainer), &ImageContainer::NewImage, this, &MainWindow::UpdateTimer));
     HANDLE_CONNECTION_RESULT(
         QObject::connect(m_updateFPSDisplayTimer, &QTimer::timeout, this, &MainWindow::UpdateFPSLCDDisplay));
     m_updateFPSDisplayTimer->start(UPDATE_RATE_MS_FPS_TIMER);
@@ -776,11 +776,11 @@ void MainWindow::StopRecording()
     HANDLE_CONNECTION_RESULT(
         QObject::disconnect(&(this->m_imageContainer), &ImageContainer::NewImage, this, &MainWindow::CountImages));
     HANDLE_CONNECTION_RESULT(
-        QObject::disconnect(&(this->m_imageContainer), &ImageContainer::NewImage, this, &MainWindow::updateTimer));
+        QObject::disconnect(&(this->m_imageContainer), &ImageContainer::NewImage, this, &MainWindow::UpdateTimer));
     HANDLE_CONNECTION_RESULT(
         QObject::disconnect(m_updateFPSDisplayTimer, &QTimer::timeout, this, &MainWindow::UpdateFPSLCDDisplay));
     QMetaObject::invokeMethod(this->ui->fpsLCDNumber, "display", Qt::QueuedConnection, Q_ARG(QString, ""));
-    this->stopTimer();
+    this->StopTimer();
     this->m_IOWork.reset();
     this->m_IOWork = nullptr;
     this->m_IOService.stop();
@@ -850,7 +850,7 @@ void MainWindow::StopPollingThread()
     m_imageContainerThread.join();
 }
 
-void MainWindow::handleAutoexposureCheckboxClicked(bool setAutoexposure)
+void MainWindow::HandleAutoexposureCheckboxClicked(bool setAutoexposure)
 {
     this->m_cameraInterface.m_camera->AutoExposure(setAutoexposure);
     ui->exposureSlider->setEnabled(!setAutoexposure);
@@ -858,7 +858,7 @@ void MainWindow::handleAutoexposureCheckboxClicked(bool setAutoexposure)
     UpdateExposure();
 }
 
-void MainWindow::handleWhiteBalanceButtonClicked()
+void MainWindow::HandleWhiteBalanceButtonClicked()
 {
     if (m_referenceRecordingThread.joinable())
     {
@@ -867,7 +867,7 @@ void MainWindow::handleWhiteBalanceButtonClicked()
     m_referenceRecordingThread = boost::thread(&MainWindow::RecordReferenceImages, this, "white");
 }
 
-void MainWindow::handleDarkCorrectionButtonClicked()
+void MainWindow::HandleDarkCorrectionButtonClicked()
 {
     if (m_referenceRecordingThread.joinable())
     {
@@ -919,7 +919,7 @@ void MainWindow::RecordReferenceImages(const QString &referenceType)
     {
         int exp_time = m_cameraInterface.m_camera->GetExposureMs();
         int waitTime = 2 * exp_time;
-        wait(waitTime);
+        WaitMilliseconds(waitTime);
         this->RecordImage(true);
         int progress = static_cast<int>((static_cast<float>(i + 1) / NR_REFERENCE_IMAGES_TO_RECORD) * 100);
         QMetaObject::invokeMethod(ui->progressBar, "setValue", Qt::QueuedConnection, Q_ARG(int, progress));
@@ -955,7 +955,7 @@ void MainWindow::RestoreLineEditStyle(QLineEdit *lineEdit)
     lineEdit->setStyleSheet(FIELD_ORIGINAL_STYLE);
 }
 
-void MainWindow::handleExposureLineEditReturnPressed()
+void MainWindow::HandleExposureLineEditReturnPressed()
 {
     m_labelExp = ui->exposureLineEdit->text();
     m_cameraInterface.m_camera->SetExposureMs(m_labelExp.toInt());
@@ -963,19 +963,19 @@ void MainWindow::handleExposureLineEditReturnPressed()
     RestoreLineEditStyle(ui->exposureLineEdit);
 }
 
-void MainWindow::handleFilePrefixLineEditReturnPressed()
+void MainWindow::HandleFilePrefixLineEditReturnPressed()
 {
     m_recPrefixLineEdit = ui->filePrefixLineEdit->text();
     RestoreLineEditStyle(ui->filePrefixLineEdit);
 }
 
-void MainWindow::handleSubFolderExtrasLineEditReturnPressed()
+void MainWindow::HandleSubFolderExtrasLineEditReturnPressed()
 {
     m_extrasSubFolder = ui->subFolderExtrasLineEdit->text();
     RestoreLineEditStyle(ui->subFolderExtrasLineEdit);
 }
 
-void MainWindow::handleViewerFileLineEditReturnPressed()
+void MainWindow::HandleViewerFileLineEditReturnPressed()
 {
     auto file = QFile(ui->viewerFileLineEdit->text());
     if (file.exists())
@@ -990,19 +990,19 @@ void MainWindow::handleViewerFileLineEditReturnPressed()
     }
 }
 
-void MainWindow::handleFilePrefixExtrasLineEditReturnPressed()
+void MainWindow::HandleFilePrefixExtrasLineEditReturnPressed()
 {
     m_extrasFilePrefix = ui->filePrefixExtrasLineEdit->text();
     RestoreLineEditStyle(ui->filePrefixExtrasLineEdit);
 }
 
-void MainWindow::handleBaseFolderLineEditReturnPressed()
+void MainWindow::HandleBaseFolderLineEditReturnPressed()
 {
     m_baseFolderLoc = ui->baseFolderLineEdit->text();
     RestoreLineEditStyle(ui->baseFolderLineEdit);
 }
 
-void MainWindow::handleLogTextLineEditReturnPressed()
+void MainWindow::HandleLogTextLineEditReturnPressed()
 {
     QString timestamp;
     QString trigger_message = ui->logTextLineEdit->text();
@@ -1023,37 +1023,37 @@ void MainWindow::handleLogTextLineEditReturnPressed()
     ui->logTextLineEdit->clear();
 }
 
-void MainWindow::handleFilePrefixLineEditTextEdited(const QString &newText)
+void MainWindow::HandleFilePrefixLineEditTextEdited(const QString &newText)
 {
     UpdateComponentEditedStyle(ui->filePrefixLineEdit, newText, m_recPrefixLineEdit);
 }
 
-void MainWindow::handleSubFolderExtrasLineEditTextEdited(const QString &newText)
+void MainWindow::HandleSubFolderExtrasLineEditTextEdited(const QString &newText)
 {
     UpdateComponentEditedStyle(ui->subFolderExtrasLineEdit, newText, m_extrasSubFolder);
 }
 
-void MainWindow::handleExposureLineEditTextEdited(const QString &newText)
+void MainWindow::HandleExposureLineEditTextEdited(const QString &newText)
 {
     UpdateComponentEditedStyle(ui->exposureLineEdit, newText, m_labelExp);
 }
 
-void MainWindow::handleFilePrefixExtrasLineEditTextEdited(const QString &newText)
+void MainWindow::HandleFilePrefixExtrasLineEditTextEdited(const QString &newText)
 {
     UpdateComponentEditedStyle(ui->filePrefixExtrasLineEdit, newText, m_extrasFilePrefix);
 }
 
-void MainWindow::handleLogTextLineEditTextEdited(const QString &newText)
+void MainWindow::HandleLogTextLineEditTextEdited(const QString &newText)
 {
     UpdateComponentEditedStyle(ui->logTextLineEdit, newText, m_triggerText);
 }
 
-void MainWindow::handleBaseFolderLineEditTextEdited(const QString &newText)
+void MainWindow::HandleBaseFolderLineEditTextEdited(const QString &newText)
 {
     UpdateComponentEditedStyle(ui->baseFolderLineEdit, newText, m_baseFolderLoc);
 }
 
-void MainWindow::handleViewerFileLineEditTextEdited(const QString &newText)
+void MainWindow::HandleViewerFileLineEditTextEdited(const QString &newText)
 {
     UpdateComponentEditedStyle(ui->viewerFileLineEdit, newText, m_viewerFilePath);
 }
@@ -1069,7 +1069,7 @@ QString MainWindow::FormatTimeStamp(const QString &timestamp)
  * updates frames per second label in GUI when the number of skipped frames is
  * modified
  */
-void MainWindow::handleSkipFramesSpinBoxValueChanged()
+void MainWindow::HandleSkipFramesSpinBoxValueChanged()
 {
     // spin boxes do not have a returnPressed slot in Qt, which is why the value
     // is always updated upon changes
@@ -1079,7 +1079,7 @@ void MainWindow::handleSkipFramesSpinBoxValueChanged()
     ui->hzLabel->setText(QString::number((double)(1000.0 / (exp_ms * (nSkipFrames + 1))), 'g', 2));
 }
 
-void MainWindow::handleCameraListComboBoxCurrentIndexChanged(int index)
+void MainWindow::HandleCameraListComboBoxCurrentIndexChanged(int index)
 {
     boost::lock_guard<boost::mutex> guard(m_mutexImageRecording);
     // image acquisition should be stopped when index 0 (no camera) is selected
@@ -1144,7 +1144,7 @@ void MainWindow::handleCameraListComboBoxCurrentIndexChanged(int index)
     }
 }
 
-void MainWindow::handleReloadCamerasPushButtonClicked()
+void MainWindow::HandleReloadCamerasPushButtonClicked()
 {
     QStringList cameraList = m_cameraInterface.GetAvailableCameraIdentifiers();
     // Only add new camera models
@@ -1228,27 +1228,27 @@ void MainWindow::UpdateImage(cv::Mat &image, QImage::Format format, QGraphicsVie
 
 void MainWindow::UpdateRGBImage(cv::Mat &image)
 {
-    UpdateImage(image, QImage::Format_RGB888, this->ui->rgbImageGraphicsView, this->rgbPixMapItem,
-                this->rgbScene.get());
+    UpdateImage(image, QImage::Format_RGB888, this->ui->rgbImageGraphicsView, this->m_rgbPixMapItem,
+                this->m_rgbScene.get());
 }
 
 void MainWindow::UpdateRawImage(cv::Mat &image)
 {
-    UpdateImage(image, QImage::Format_BGR888, this->ui->rawImageGraphicsView, this->rawPixMapItem,
-                this->rawScene.get());
+    UpdateImage(image, QImage::Format_BGR888, this->ui->rawImageGraphicsView, this->m_rawPixMapItem,
+                this->m_rawScene.get());
 }
 
 void MainWindow::UpdateRawViewerImage(cv::Mat &image)
 {
-    UpdateImage(image, QImage::Format_Grayscale8, this->ui->viewerGraphicsView, this->rawViewerPixMapItem,
-                this->rawViewerScene.get());
+    UpdateImage(image, QImage::Format_Grayscale8, this->ui->viewerGraphicsView, this->m_rawViewerPixMapItem,
+                this->m_rawViewerScene.get());
 }
 
 void MainWindow::SetGraphicsViewScene()
 {
-    this->ui->rgbImageGraphicsView->setScene(this->rgbScene.get());
-    this->ui->rawImageGraphicsView->setScene(this->rawScene.get());
-    this->ui->viewerGraphicsView->setScene(this->rawViewerScene.get());
+    this->ui->rgbImageGraphicsView->setScene(this->m_rgbScene.get());
+    this->ui->rawImageGraphicsView->setScene(this->m_rawScene.get());
+    this->ui->viewerGraphicsView->setScene(this->m_rawViewerScene.get());
 }
 
 bool MainWindow::IsSaturationButtonChecked()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -96,10 +96,10 @@ void MainWindow::SetUpConnections()
         QObject::connect(this, &MainWindow::ViewerImageProcessingComplete, this, &MainWindow::UpdateRawViewerImage));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerFileButton, &QPushButton::clicked, this,
                                               &MainWindow::HandleViewerFileButtonClicked));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::HandleFilePrefixLineEditTextEdited));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::HandleFilePrefixLineEditReturnPressed));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->fileNameLineEdit, &QLineEdit::textEdited, this,
+                                              &MainWindow::HandleFileNameLineEditTextEdited));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->fileNameLineEdit, &QLineEdit::returnPressed, this,
+                                              &MainWindow::HandleFileNameLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->autoexposureCheckbox, &QCheckBox::clicked, this,
                                               &MainWindow::HandleAutoexposureCheckboxClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->whiteBalanceButton, &QPushButton::clicked, this,
@@ -116,10 +116,10 @@ void MainWindow::SetUpConnections()
                                               &MainWindow::HandleCameraListComboBoxCurrentIndexChanged));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->reloadCamerasPushButton, &QPushButton::clicked, this,
                                               &MainWindow::HandleReloadCamerasPushButtonClicked));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixSnapshotsLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::HandleFilePrefixSnapshotsLineEditTextEdited));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixSnapshotsLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::HandleFilePrefixSnapshotsLineEditReturnPressed));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->fileNameSnapshotsLineEdit, &QLineEdit::textEdited, this,
+                                              &MainWindow::HandleFileNameSnapshotsLineEditTextEdited));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->fileNameSnapshotsLineEdit, &QLineEdit::returnPressed, this,
+                                              &MainWindow::HandleFileNameSnapshotsLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::returnPressed, this,
                                               &MainWindow::HandleBaseFolderLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::textEdited, this,
@@ -264,15 +264,15 @@ void MainWindow::RecordSnapshots()
 {
     int nr_images = ui->nSnapshotsSpinBox->value();
     QMetaObject::invokeMethod(ui->nSnapshotsSpinBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
-    QMetaObject::invokeMethod(ui->filePrefixSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
+    QMetaObject::invokeMethod(ui->fileNameSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
 
-    std::string filePrefix = ui->filePrefixSnapshotsLineEdit->text().toUtf8().constData();
+    std::string fileName = ui->fileNameSnapshotsLineEdit->text().toUtf8().constData();
 
-    if (filePrefix.empty())
+    if (fileName.empty())
     {
-        filePrefix = m_recPrefixLineEdit.toUtf8().constData();
+        fileName = m_fileName.toUtf8().constData();
     }
-    QString filePath = GetFullFilenameStandardFormat(std::move(filePrefix), ".b2nd", "");
+    QString filePath = GetFullFilenameStandardFormat(std::move(fileName), ".b2nd", "");
     auto image = m_imageContainer.GetCurrentImage();
     FileImage snapshotsFile(filePath.toStdString().c_str(), image.height, image.width);
 
@@ -290,7 +290,7 @@ void MainWindow::RecordSnapshots()
     LOG_XILENS(info) << "Closed snapshot recording file";
     QMetaObject::invokeMethod(ui->progressBar, "setValue", Qt::QueuedConnection, Q_ARG(int, 0));
     QMetaObject::invokeMethod(ui->nSnapshotsSpinBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
-    QMetaObject::invokeMethod(ui->filePrefixSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
+    QMetaObject::invokeMethod(ui->fileNameSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
 }
 
 void MainWindow::HandleSnapshotButtonClicked()
@@ -507,7 +507,7 @@ void MainWindow::HandleElementsWhileRecording(bool recordingInProgress)
     if (recordingInProgress)
     {
         QMetaObject::invokeMethod(ui->baseFolderButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
-        QMetaObject::invokeMethod(ui->filePrefixLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
+        QMetaObject::invokeMethod(ui->fileNameLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->cameraListComboBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->whiteBalanceButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
         QMetaObject::invokeMethod(ui->darkCorrectionButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
@@ -517,7 +517,7 @@ void MainWindow::HandleElementsWhileRecording(bool recordingInProgress)
     else
     {
         QMetaObject::invokeMethod(ui->baseFolderButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
-        QMetaObject::invokeMethod(ui->filePrefixLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
+        QMetaObject::invokeMethod(ui->fileNameLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->cameraListComboBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->whiteBalanceButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(ui->darkCorrectionButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
@@ -638,13 +638,13 @@ void MainWindow::ThreadedRecordImage()
     this->m_IOService.post([this] { RecordImage(false); });
 }
 
-void MainWindow::InitializeImageFileRecorder(std::string subFolder, std::string filePrefix)
+void MainWindow::InitializeImageFileRecorder(std::string subFolder, std::string fileName)
 {
-    if (filePrefix.empty())
+    if (fileName.empty())
     {
-        filePrefix = m_recPrefixLineEdit.toUtf8().constData();
+        fileName = m_fileName.toUtf8().constData();
     }
-    QString fullPath = GetFullFilenameStandardFormat(std::move(filePrefix), ".b2nd", std::move(subFolder));
+    QString fullPath = GetFullFilenameStandardFormat(std::move(fileName), ".b2nd", std::move(subFolder));
     this->m_imageContainer.InitializeFile(fullPath.toStdString().c_str());
 }
 
@@ -795,7 +795,7 @@ void MainWindow::CreateFolderIfNecessary(const QString &folder)
     }
 }
 
-QString MainWindow::GetFullFilenameStandardFormat(std::string &&filePrefix, const std::string &extension,
+QString MainWindow::GetFullFilenameStandardFormat(std::string &&fileName, const std::string &extension,
                                                   std::string &&subFolder)
 {
     QString writingFolder = GetWritingFolder() + QDir::separator() + QString::fromStdString(subFolder);
@@ -805,18 +805,18 @@ QString MainWindow::GetFullFilenameStandardFormat(std::string &&filePrefix, cons
     }
     MainWindow::CreateFolderIfNecessary(writingFolder);
 
-    QString fileName;
+    QString fullFileName;
     if (!m_testMode)
     {
-        fileName = QString::fromStdString(filePrefix);
+        fullFileName = QString::fromStdString(fileName);
     }
     else
     {
-        fileName = QString("test");
+        fullFileName = QString("test");
     }
-    fileName += QString::fromStdString(extension);
+    fullFileName += QString::fromStdString(extension);
 
-    return QDir::cleanPath(writingFolder + fileName);
+    return QDir::cleanPath(writingFolder + fullFileName);
 }
 
 void MainWindow::StartPollingThread()
@@ -938,10 +938,10 @@ void MainWindow::RestoreLineEditStyle(QLineEdit *lineEdit)
     lineEdit->setStyleSheet(FIELD_ORIGINAL_STYLE);
 }
 
-void MainWindow::HandleFilePrefixLineEditReturnPressed()
+void MainWindow::HandleFileNameLineEditReturnPressed()
 {
-    m_recPrefixLineEdit = ui->filePrefixLineEdit->text();
-    RestoreLineEditStyle(ui->filePrefixLineEdit);
+    m_fileName = ui->fileNameLineEdit->text();
+    RestoreLineEditStyle(ui->fileNameLineEdit);
 }
 
 void MainWindow::HandleViewerFileLineEditReturnPressed()
@@ -959,10 +959,20 @@ void MainWindow::HandleViewerFileLineEditReturnPressed()
     }
 }
 
-void MainWindow::HandleFilePrefixSnapshotsLineEditReturnPressed()
+void MainWindow::HandleFileNameSnapshotsLineEditReturnPressed()
 {
-    m_snapshotsFilePrefix = ui->filePrefixSnapshotsLineEdit->text();
-    RestoreLineEditStyle(ui->filePrefixSnapshotsLineEdit);
+    if (m_fileName == ui->fileNameSnapshotsLineEdit->text())
+    {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setWindowTitle("Error");
+        msgBox.setText("<b>Invalid file name.</b>");
+        msgBox.setInformativeText("Snapshot file name cannot be the same as video recording file name.");
+        msgBox.exec();
+        return;
+    }
+    m_snapshotsFileName = ui->fileNameSnapshotsLineEdit->text();
+    RestoreLineEditStyle(ui->fileNameSnapshotsLineEdit);
 }
 
 void MainWindow::HandleBaseFolderLineEditReturnPressed()
@@ -992,14 +1002,14 @@ void MainWindow::HandleLogTextLineEditReturnPressed()
     ui->logTextLineEdit->clear();
 }
 
-void MainWindow::HandleFilePrefixLineEditTextEdited(const QString &newText)
+void MainWindow::HandleFileNameLineEditTextEdited(const QString &newText)
 {
-    UpdateComponentEditedStyle(ui->filePrefixLineEdit, newText, m_recPrefixLineEdit);
+    UpdateComponentEditedStyle(ui->fileNameLineEdit, newText, m_fileName);
 }
 
-void MainWindow::HandleFilePrefixSnapshotsLineEditTextEdited(const QString &newText)
+void MainWindow::HandleFileNameSnapshotsLineEditTextEdited(const QString &newText)
 {
-    UpdateComponentEditedStyle(ui->filePrefixSnapshotsLineEdit, newText, m_snapshotsFilePrefix);
+    UpdateComponentEditedStyle(ui->fileNameSnapshotsLineEdit, newText, m_snapshotsFileName);
 }
 
 void MainWindow::HandleLogTextLineEditTextEdited(const QString &newText)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -116,20 +116,16 @@ void MainWindow::SetUpConnections()
                                               &MainWindow::HandleCameraListComboBoxCurrentIndexChanged));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->reloadCamerasPushButton, &QPushButton::clicked, this,
                                               &MainWindow::HandleReloadCamerasPushButtonClicked));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixExtrasLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::HandleFilePrefixExtrasLineEditTextEdited));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixExtrasLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::HandleFilePrefixExtrasLineEditReturnPressed));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixSnapshotsLineEdit, &QLineEdit::textEdited, this,
+                                              &MainWindow::HandleFilePrefixSnapshotsLineEditTextEdited));
+    HANDLE_CONNECTION_RESULT(QObject::connect(ui->filePrefixSnapshotsLineEdit, &QLineEdit::returnPressed, this,
+                                              &MainWindow::HandleFilePrefixSnapshotsLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::returnPressed, this,
                                               &MainWindow::HandleBaseFolderLineEditReturnPressed));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderExtrasLineEdit, &QLineEdit::textEdited, this,
-                                              &MainWindow::HandleSubFolderExtrasLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->baseFolderLineEdit, &QLineEdit::textEdited, this,
                                               &MainWindow::HandleBaseFolderLineEditTextEdited));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerFileLineEdit, &QLineEdit::textEdited, this,
                                               &MainWindow::HandleViewerFileLineEditTextEdited));
-    HANDLE_CONNECTION_RESULT(QObject::connect(ui->subFolderExtrasLineEdit, &QLineEdit::returnPressed, this,
-                                              &MainWindow::HandleSubFolderExtrasLineEditReturnPressed));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerFileLineEdit, &QLineEdit::returnPressed, this,
                                               &MainWindow::HandleViewerFileLineEditReturnPressed));
 }
@@ -202,8 +198,6 @@ void MainWindow::EnableUi(bool enable)
     SetGraphicsViewScene();
     this->ui->exposureSlider->setEnabled(enable);
     this->ui->logTextLineEdit->setEnabled(enable);
-    QLayout *layoutExtras = ui->extrasVerticalLayout->layout();
-    EnableWidgetsInLayout(layoutExtras, enable);
 }
 
 void MainWindow::SetUpCustomUiComponents()
@@ -270,17 +264,15 @@ void MainWindow::RecordSnapshots()
 {
     int nr_images = ui->nSnapshotsSpinBox->value();
     QMetaObject::invokeMethod(ui->nSnapshotsSpinBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
-    QMetaObject::invokeMethod(ui->filePrefixExtrasLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
-    QMetaObject::invokeMethod(ui->subFolderExtrasLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
+    QMetaObject::invokeMethod(ui->filePrefixSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
 
-    std::string filePrefix = ui->filePrefixExtrasLineEdit->text().toUtf8().constData();
-    std::string subFolder = ui->subFolderExtrasLineEdit->text().toUtf8().constData();
+    std::string filePrefix = ui->filePrefixSnapshotsLineEdit->text().toUtf8().constData();
 
     if (filePrefix.empty())
     {
         filePrefix = m_recPrefixLineEdit.toUtf8().constData();
     }
-    QString filePath = GetFullFilenameStandardFormat(std::move(filePrefix), ".b2nd", std::move(subFolder));
+    QString filePath = GetFullFilenameStandardFormat(std::move(filePrefix), ".b2nd", "");
     auto image = m_imageContainer.GetCurrentImage();
     FileImage snapshotsFile(filePath.toStdString().c_str(), image.height, image.width);
 
@@ -298,8 +290,7 @@ void MainWindow::RecordSnapshots()
     LOG_XILENS(info) << "Closed snapshot recording file";
     QMetaObject::invokeMethod(ui->progressBar, "setValue", Qt::QueuedConnection, Q_ARG(int, 0));
     QMetaObject::invokeMethod(ui->nSnapshotsSpinBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
-    QMetaObject::invokeMethod(ui->filePrefixExtrasLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
-    QMetaObject::invokeMethod(ui->subFolderExtrasLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
+    QMetaObject::invokeMethod(ui->filePrefixSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
 }
 
 void MainWindow::HandleSnapshotButtonClicked()
@@ -953,12 +944,6 @@ void MainWindow::HandleFilePrefixLineEditReturnPressed()
     RestoreLineEditStyle(ui->filePrefixLineEdit);
 }
 
-void MainWindow::HandleSubFolderExtrasLineEditReturnPressed()
-{
-    m_extrasSubFolder = ui->subFolderExtrasLineEdit->text();
-    RestoreLineEditStyle(ui->subFolderExtrasLineEdit);
-}
-
 void MainWindow::HandleViewerFileLineEditReturnPressed()
 {
     auto file = QFile(ui->viewerFileLineEdit->text());
@@ -974,10 +959,10 @@ void MainWindow::HandleViewerFileLineEditReturnPressed()
     }
 }
 
-void MainWindow::HandleFilePrefixExtrasLineEditReturnPressed()
+void MainWindow::HandleFilePrefixSnapshotsLineEditReturnPressed()
 {
-    m_extrasFilePrefix = ui->filePrefixExtrasLineEdit->text();
-    RestoreLineEditStyle(ui->filePrefixExtrasLineEdit);
+    m_snapshotsFilePrefix = ui->filePrefixSnapshotsLineEdit->text();
+    RestoreLineEditStyle(ui->filePrefixSnapshotsLineEdit);
 }
 
 void MainWindow::HandleBaseFolderLineEditReturnPressed()
@@ -1012,14 +997,9 @@ void MainWindow::HandleFilePrefixLineEditTextEdited(const QString &newText)
     UpdateComponentEditedStyle(ui->filePrefixLineEdit, newText, m_recPrefixLineEdit);
 }
 
-void MainWindow::HandleSubFolderExtrasLineEditTextEdited(const QString &newText)
+void MainWindow::HandleFilePrefixSnapshotsLineEditTextEdited(const QString &newText)
 {
-    UpdateComponentEditedStyle(ui->subFolderExtrasLineEdit, newText, m_extrasSubFolder);
-}
-
-void MainWindow::HandleFilePrefixExtrasLineEditTextEdited(const QString &newText)
-{
-    UpdateComponentEditedStyle(ui->filePrefixExtrasLineEdit, newText, m_extrasFilePrefix);
+    UpdateComponentEditedStyle(ui->filePrefixSnapshotsLineEdit, newText, m_snapshotsFilePrefix);
 }
 
 void MainWindow::HandleLogTextLineEditTextEdited(const QString &newText)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -138,31 +138,9 @@ class MainWindow : public QMainWindow
     void StopSnapshotsThread();
 
     /**
-     * @brief Updates the saturation percentage on the LCD displays.
-     *
-     * @param image The input image of type CV_8UC1. It must be non-empty.
-     * @throws std::invalid_argument if the input matrix is empty or of the wrong type.
-     */
-    void UpdateSaturationPercentageLCDDisplays(cv::Mat &image) const;
-
-    /**
      * Updates the frames per second that are stored to file on the UI.
      */
     void UpdateFPSLCDDisplay();
-
-    /**
-     * Updates the RGB image displayed in the GUI.
-     *
-     * @param image OpenCv matrix containing an 8bit (per channel) RGB image to be displayed.
-     */
-    void UpdateRGBImage(cv::Mat &image);
-
-    /**
-     * Updates the raw image displayed in the GUI.
-     *
-     * @param image OpenCV matrix containing an 8bit single channel image to be displayed.
-     */
-    void UpdateRawImage(cv::Mat &image);
 
     /**
      * Updates the raw image displayed in the viewer tab.
@@ -252,6 +230,29 @@ class MainWindow : public QMainWindow
      * @param mat OpenCV matrix containing the image to display. This should be a one channel image.
      */
     void ViewerImageProcessingComplete(cv::Mat &mat);
+
+  public slots:
+    /**
+     * Qt slot that updates the RGB image displayed in the GUI.
+     *
+     * @param image OpenCv matrix containing an 8bit (per channel) RGB image to be displayed.
+     */
+    void UpdateRGBImage(cv::Mat &image);
+
+    /**
+     * Qt slot that updates the raw image displayed in the GUI.
+     *
+     * @param image OpenCV matrix containing an 8bit single channel image to be displayed.
+     */
+    void UpdateRawImage(cv::Mat &image);
+
+    /**
+     * Qt slot that updates the saturation percentage on the LCD displays.
+     *
+     * @param image The input image of type CV_8UC1. It must be non-empty.
+     * @throws std::invalid_argument if the input matrix is empty or of the wrong type.
+     */
+    void UpdateSaturationPercentageLCDDisplays(cv::Mat &image) const;
 
   private slots:
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -367,25 +367,18 @@ class MainWindow : public QMainWindow
      *
      * @param newText edited text.
      */
-    void HandleFilePrefixExtrasLineEditTextEdited(const QString &newText);
+    void HandleFilePrefixSnapshotsLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when the return key is pressed on the file prefix field
      * for snapshot images in the UI.
      */
-    void HandleFilePrefixExtrasLineEditReturnPressed();
+    void HandleFilePrefixSnapshotsLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the return key is pressed on the base folder field line edit in the UI.
      */
     void HandleBaseFolderLineEditReturnPressed();
-
-    /**
-     * Qt slot triggered when extras sub folder field is edited in the UI.
-     *
-     * @param newText edited text.
-     */
-    void HandleSubFolderExtrasLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when base folder field is edited in the UI.
@@ -400,12 +393,6 @@ class MainWindow : public QMainWindow
      * @param newText edited text
      */
     void HandleViewerFileLineEditTextEdited(const QString &newText);
-
-    /**
-     * Qt slot triggered when the return key is pressed on the sub folder field in
-     * the extras tab in the UI.
-     */
-    void HandleSubFolderExtrasLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the return key is pressed in the file path field of the viewer tab.
@@ -640,12 +627,6 @@ class MainWindow : public QMainWindow
     QString m_recPrefixLineEdit;
 
     /**
-     * Folder path where extra images are to be stored (e.g. snapshots). This is a
-     * folder inside the base folder.
-     */
-    QString m_extrasSubFolder;
-
-    /**
      * Trigger text entered to the log function of the UI.
      */
     QString m_triggerText;
@@ -668,7 +649,7 @@ class MainWindow : public QMainWindow
     /**
      * File prefix used for snapshot images.
      */
-    QString m_extrasFilePrefix;
+    QString m_snapshotsFilePrefix;
 
     /**
      * Elapsed timer used for the timer displayed in the UI.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -298,19 +298,19 @@ class MainWindow : public QMainWindow
 
     /**
      * Qt slot triggered when the return key is pressed on the field that defines
-     * the file prefix in the UI. It updates the member variable that stores the
+     * the file name in the UI. It updates the member variable that stores the
      * value.
      */
-    void HandleFilePrefixLineEditReturnPressed();
+    void HandleFileNameLineEditReturnPressed();
 
     /**
-     * Qt slot triggered when the prefix file name is edited. It changes the
+     * Qt slot triggered when the file name is edited. It changes the
      * appearance of the field in the UI. It does not change the value of the
-     * member variable that stores the file prefix name.
+     * member variable that stores the file name.
      *
      * @param newText edited text.
      */
-    void HandleFilePrefixLineEditTextEdited(const QString &newText);
+    void HandleFileNameLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when auto exposure checkbox is pressed. Handles control
@@ -363,17 +363,19 @@ class MainWindow : public QMainWindow
     void HandleReloadCamerasPushButtonClicked();
 
     /**
-     * Qt slot triggered when file name prefix for snapshots is edited on the UI.
+     * Qt slot triggered when file name for snapshots is edited on the UI.
      *
      * @param newText edited text.
      */
-    void HandleFilePrefixSnapshotsLineEditTextEdited(const QString &newText);
+    void HandleFileNameSnapshotsLineEditTextEdited(const QString &newText);
 
     /**
-     * Qt slot triggered when the return key is pressed on the file prefix field
+     * Qt slot triggered when the return key is pressed on the file name field
      * for snapshot images in the UI.
+     * This method will show a en error message box when the name of the snapshot file is the same as the file
+     * where the video is to be recorded.
      */
-    void HandleFilePrefixSnapshotsLineEditReturnPressed();
+    void HandleFileNameSnapshotsLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the return key is pressed on the base folder field line edit in the UI.
@@ -477,8 +479,7 @@ class MainWindow : public QMainWindow
     static void CreateFolderIfNecessary(const QString &folder);
 
     /**
-     * Records image to specified sub folder and using specified file prefix to
-     * name the file.
+     * Records image to specified sub folder and using specified file name.
      *
      * @param ignoreSkipping ignores the number of frames to skip and stores the
      * image anyways.
@@ -495,9 +496,9 @@ class MainWindow : public QMainWindow
      * to store all images while recording to a single file.
      *
      * @param subFolder folder where data will be stored.
-     * @param filePrefix file prefix used for the file name.
+     * @param fileName file name.
      */
-    void InitializeImageFileRecorder(std::string subFolder = "", std::string filePrefix = "");
+    void InitializeImageFileRecorder(std::string subFolder = "", std::string fileName = "");
 
     /**
      * Indicates if an image should be recorded to file or not depending on the
@@ -558,14 +559,14 @@ class MainWindow : public QMainWindow
      * It automatically add the current write path and puts the name in a standard
      * format including timestamp etc.
      *
-     * @param filePrefix the name of the file (snapshot, recording, liver_image, ...).
+     * @param fileName the name of the file (snapshot, recording, liver_image, ...).
      * @param frameNumber the acquisition frame number provided by ximea.
      * @param extension file extension (.b2nd).
      * @param subFolder sometimes we want to add an additional layer of subfolder.
      * specifically when saving white/dark balance images.
      * @return
      */
-    QString GetFullFilenameStandardFormat(std::string &&filePrefix, const std::string &extension,
+    QString GetFullFilenameStandardFormat(std::string &&fileName, const std::string &extension,
                                           std::string &&subFolder);
 
     /**
@@ -622,9 +623,9 @@ class MainWindow : public QMainWindow
     void RegisterTimeImageRecorded();
 
     /**
-     * file prefix to be appended to each image file name.
+     * The file name where videos are to be stored.
      */
-    QString m_recPrefixLineEdit;
+    QString m_fileName;
 
     /**
      * Trigger text entered to the log function of the UI.
@@ -647,9 +648,9 @@ class MainWindow : public QMainWindow
     QString m_labelExp;
 
     /**
-     * File prefix used for snapshot images.
+     * File name used for snapshot images.
      */
-    QString m_snapshotsFilePrefix;
+    QString m_snapshotsFileName;
 
     /**
      * Elapsed timer used for the timer displayed in the UI.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -262,11 +262,11 @@ class MainWindow : public QMainWindow
     void HandleSnapshotButtonClicked();
 
     /**
-     * Qt slot triggered when the camera exposure slider is modified.
+     * Qt slot triggered when the camera exposure value is modified either from the slider or the spinbox.
      *
      * @param value exposure value.
      */
-    void HandleExposureSliderValueChanged(int value);
+    void HandleExposureValueChanged(int value);
 
     /**
      * Qt slot triggered when the image index slider in the Viewer tab of the application changes value.
@@ -295,21 +295,6 @@ class MainWindow : public QMainWindow
      * a dialog where a file can be selected.
      */
     void HandleViewerFileButtonClicked();
-
-    /**
-     * Qt slot triggered when the exposure time labels is modified manually. This
-     * changes the appearance of the field but does not trigger the change in the
-     * camera. Return key needs to be pressed for the change to be applied.
-     *
-     * @param newText edited text.
-     */
-    void HandleExposureLineEditTextEdited(const QString &newText);
-
-    /**
-     * Qt slot triggered when return key is pressed after modifying the exposure
-     * time. This is synchronized with the exposure time slider.
-     */
-    void HandleExposureLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the return key is pressed on the field that defines
@@ -668,7 +653,7 @@ class MainWindow : public QMainWindow
     /**
      * Folder path where all data is to be stored.
      */
-    QString m_baseFolderLoc;
+    QString m_baseFolderPath;
 
     /**
      * Path to a .b2nd file to be displayed in the viewer tab.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -259,21 +259,21 @@ class MainWindow : public QMainWindow
      * Qt slot triggered when the snapshot button is pressed. Triggers the
      * recording of snapshot images or stops it when pressed a second time.
      */
-    void handleSnapshotButtonClicked();
+    void HandleSnapshotButtonClicked();
 
     /**
      * Qt slot triggered when the camera exposure slider is modified.
      *
      * @param value exposure value.
      */
-    void handleExposureSliderValueChanged(int value);
+    void HandleExposureSliderValueChanged(int value);
 
     /**
      * Qt slot triggered when the image index slider in the Viewer tab of the application changes value.
      *
      * @param value The new value of the slider.
      */
-    void handleViewerImageSliderValueChanged(int value);
+    void HandleViewerImageSliderValueChanged(int value);
 
     /**
      * Qt slot triggered when the record button is pressed. Stars the continuous
@@ -282,19 +282,19 @@ class MainWindow : public QMainWindow
      *
      * @param clicked indicates if the button is clicked.
      */
-    void handleRecordButtonClicked(bool clicked);
+    void HandleRecordButtonClicked(bool clicked);
 
     /**
      * Qt slot triggered when the button to choose a base folder is clicked. Opens
      * a dialog where a folder can be selected.
      */
-    void handleBaseFolderButtonClicked();
+    void HandleBaseFolderButtonClicked();
 
     /**
      * Qt slot triggered when the file button in the viewer tab is clicked. Opens
      * a dialog where a file can be selected.
      */
-    void handleViewerFileButtonClicked();
+    void HandleViewerFileButtonClicked();
 
     /**
      * Qt slot triggered when the exposure time labels is modified manually. This
@@ -303,20 +303,20 @@ class MainWindow : public QMainWindow
      *
      * @param newText edited text.
      */
-    void handleExposureLineEditTextEdited(const QString &newText);
+    void HandleExposureLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when return key is pressed after modifying the exposure
      * time. This is synchronized with the exposure time slider.
      */
-    void handleExposureLineEditReturnPressed();
+    void HandleExposureLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the return key is pressed on the field that defines
      * the file prefix in the UI. It updates the member variable that stores the
      * value.
      */
-    void handleFilePrefixLineEditReturnPressed();
+    void HandleFilePrefixLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the prefix file name is edited. It changes the
@@ -325,25 +325,25 @@ class MainWindow : public QMainWindow
      *
      * @param newText edited text.
      */
-    void handleFilePrefixLineEditTextEdited(const QString &newText);
+    void HandleFilePrefixLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when auto exposure checkbox is pressed. Handles control
      * of the exposure time to camera.
      */
-    void handleAutoexposureCheckboxClicked(bool setAutoexposure);
+    void HandleAutoexposureCheckboxClicked(bool setAutoexposure);
 
     /**
      * Qt slot triggered when white balance button is pressed. Records a new white
      * image and sets it in the network model.
      */
-    void handleWhiteBalanceButtonClicked();
+    void HandleWhiteBalanceButtonClicked();
 
     /**
      * Qt slot triggered when the dark correction button is pressed. Records a new
      * dark image and sets it in the network model.
      */
-    void handleDarkCorrectionButtonClicked();
+    void HandleDarkCorrectionButtonClicked();
 
     /**
      * Qt slot triggered when the trigger text is edited. It only changes the
@@ -351,81 +351,81 @@ class MainWindow : public QMainWindow
      *
      * @param newText edited text.
      */
-    void handleLogTextLineEditTextEdited(const QString &newText);
+    void HandleLogTextLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when the return key is pressed on the trigger text field.
      * It logs the message to the log file and displays it on the UI.
      */
-    void handleLogTextLineEditReturnPressed();
+    void HandleLogTextLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the spin box containing the number of images to skip
      * while recording is modified. It restyles the appearance of the field.
      */
-    void handleSkipFramesSpinBoxValueChanged();
+    void HandleSkipFramesSpinBoxValueChanged();
 
     /**
      * Qt slot triggered when a new camera is selected from the drop-down menu.
      *
      * @param index index corresponding to the element selected from the combo box.
      */
-    void handleCameraListComboBoxCurrentIndexChanged(int index);
+    void HandleCameraListComboBoxCurrentIndexChanged(int index);
 
     /**
      * Checks for connected XIMEA cameras and populates the dropdown list of available cameras.
      */
-    void handleReloadCamerasPushButtonClicked();
+    void HandleReloadCamerasPushButtonClicked();
 
     /**
      * Qt slot triggered when file name prefix for snapshots is edited on the UI.
      *
      * @param newText edited text.
      */
-    void handleFilePrefixExtrasLineEditTextEdited(const QString &newText);
+    void HandleFilePrefixExtrasLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when the return key is pressed on the file prefix field
      * for snapshot images in the UI.
      */
-    void handleFilePrefixExtrasLineEditReturnPressed();
+    void HandleFilePrefixExtrasLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the return key is pressed on the base folder field line edit in the UI.
      */
-    void handleBaseFolderLineEditReturnPressed();
+    void HandleBaseFolderLineEditReturnPressed();
 
     /**
      * Qt slot triggered when extras sub folder field is edited in the UI.
      *
      * @param newText edited text.
      */
-    void handleSubFolderExtrasLineEditTextEdited(const QString &newText);
+    void HandleSubFolderExtrasLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when base folder field is edited in the UI.
      *
      * @param newText edited text.
      */
-    void handleBaseFolderLineEditTextEdited(const QString &newText);
+    void HandleBaseFolderLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when the file path in the viewer tab is edited through the UI.
      *
      * @param newText edited text
      */
-    void handleViewerFileLineEditTextEdited(const QString &newText);
+    void HandleViewerFileLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when the return key is pressed on the sub folder field in
      * the extras tab in the UI.
      */
-    void handleSubFolderExtrasLineEditReturnPressed();
+    void HandleSubFolderExtrasLineEditReturnPressed();
 
     /**
      * Qt slot triggered when the return key is pressed in the file path field of the viewer tab.
      */
-    void handleViewerFileLineEditReturnPressed();
+    void HandleViewerFileLineEditReturnPressed();
 
   private:
     /**
@@ -545,12 +545,12 @@ class MainWindow : public QMainWindow
     /**
      * Updates timer displayed on the UI when recordings are started.
      */
-    void updateTimer();
+    void UpdateTimer();
 
     /**
      * Stops the timer that is displayed in the UI when recordings are started.
      */
-    void stopTimer();
+    void StopTimer();
 
     /**
      * @brief MEthod used to record singe snapshot images while recording.
@@ -637,7 +637,17 @@ class MainWindow : public QMainWindow
      *
      * @param value image index to load from file
      */
-    void processViewerImageSliderValueChanged(int value);
+    void ProcessViewerImageSliderValueChanged(int value);
+
+    /**
+     * Sets the scene for RGB and raw image viewers. It defines antialiasing and smooth pixmap transformations.
+     */
+    void SetGraphicsViewScene();
+
+    /**
+     * Appends the current time to que of recorded time stamps that can be used to calculate the frames per second.
+     */
+    void RegisterTimeImageRecorded();
 
     /**
      * file prefix to be appended to each image file name.
@@ -845,42 +855,32 @@ class MainWindow : public QMainWindow
     /**
      * Smart pointer to the RGB scene where the RGB images will be displayed.
      */
-    std::unique_ptr<QGraphicsScene> rgbScene = std::make_unique<QGraphicsScene>(this);
+    std::unique_ptr<QGraphicsScene> m_rgbScene = std::make_unique<QGraphicsScene>(this);
 
     /**
      * Smart pointer to raw scene where the raw unprocessed images will be displayed.
      */
-    std::unique_ptr<QGraphicsScene> rawScene = std::make_unique<QGraphicsScene>(this);
+    std::unique_ptr<QGraphicsScene> m_rawScene = std::make_unique<QGraphicsScene>(this);
 
     /**
      * Smart pointer to a scene where the images for the Viewer tab are displayed.
      */
-    std::unique_ptr<QGraphicsScene> rawViewerScene = std::make_unique<QGraphicsScene>(this);
+    std::unique_ptr<QGraphicsScene> m_rawViewerScene = std::make_unique<QGraphicsScene>(this);
 
     /**
      * Smart pointer to pixmap used to display the RGB images.
      */
-    std::unique_ptr<QGraphicsPixmapItem> rgbPixMapItem;
+    std::unique_ptr<QGraphicsPixmapItem> m_rgbPixMapItem;
 
     /**
      * Smart pointer to pixmap where raw unprocessed images will be displayed.
      */
-    std::unique_ptr<QGraphicsPixmapItem> rawPixMapItem;
+    std::unique_ptr<QGraphicsPixmapItem> m_rawPixMapItem;
 
     /**
      * Smart Pointer to a pixmap used to display the images in the RawViewer.
      */
-    std::unique_ptr<QGraphicsPixmapItem> rawViewerPixMapItem;
-
-    /**
-     * Sets the scene for RGB and raw image viewers. It defines antialiasing and smooth pixmap transformations.
-     */
-    void SetGraphicsViewScene();
-
-    /**
-     * Appends the current time to que of recorded time stamps that can be used to calculate the frames per second.
-     */
-    void RegisterTimeImageRecorded();
+    std::unique_ptr<QGraphicsPixmapItem> m_rawViewerPixMapItem;
 
     /**
      * Timer that sets the rate of updates for the FPS LCD Display in the UI.

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -169,7 +169,7 @@
                        <enum>QFrame::NoFrame</enum>
                       </property>
                       <property name="currentIndex">
-                       <number>0</number>
+                       <number>3</number>
                       </property>
                       <widget class="QWidget" name="page">
                        <property name="geometry">
@@ -228,7 +228,7 @@
                            </widget>
                           </item>
                           <item row="1" column="0">
-                           <widget class="QLabel" name="filePrefixLabel">
+                           <widget class="QLabel" name="fileNameLabel">
                             <property name="sizePolicy">
                              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                               <horstretch>0</horstretch>
@@ -247,9 +247,9 @@
                            </widget>
                           </item>
                           <item row="1" column="1">
-                           <widget class="QLineEdit" name="filePrefixLineEdit">
+                           <widget class="QLineEdit" name="fileNameLineEdit">
                             <property name="toolTip">
-                             <string>Prefix appended to the beginning each file stored</string>
+                             <string>File name used to store the video data</string>
                             </property>
                             <property name="text">
                              <string/>
@@ -582,6 +582,14 @@
                        </layout>
                       </widget>
                       <widget class="QWidget" name="page_4">
+                       <property name="geometry">
+                        <rect>
+                         <x>0</x>
+                         <y>0</y>
+                         <width>368</width>
+                         <height>230</height>
+                        </rect>
+                       </property>
                        <attribute name="label">
                         <string>Snapshots</string>
                        </attribute>
@@ -598,9 +606,9 @@
                              </widget>
                             </item>
                             <item>
-                             <widget class="QLineEdit" name="filePrefixSnapshotsLineEdit">
+                             <widget class="QLineEdit" name="fileNameSnapshotsLineEdit">
                               <property name="toolTip">
-                               <string>File prefix used to prepend to anapshot file names</string>
+                               <string>File name used to store snapshot images</string>
                               </property>
                               <property name="text">
                                <string/>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -177,11 +177,11 @@
                          <x>0</x>
                          <y>0</y>
                          <width>368</width>
-                         <height>261</height>
+                         <height>247</height>
                         </rect>
                        </property>
                        <attribute name="label">
-                        <string>File management</string>
+                        <string>Video file management</string>
                        </attribute>
                        <layout class="QVBoxLayout" name="verticalLayout_5">
                         <item>
@@ -363,7 +363,7 @@
                          <x>0</x>
                          <y>0</y>
                          <width>368</width>
-                         <height>261</height>
+                         <height>230</height>
                         </rect>
                        </property>
                        <attribute name="label">
@@ -458,7 +458,7 @@
                          <x>0</x>
                          <y>0</y>
                          <width>368</width>
-                         <height>261</height>
+                         <height>230</height>
                         </rect>
                        </property>
                        <attribute name="label">
@@ -578,6 +578,97 @@
                            </size>
                           </property>
                          </spacer>
+                        </item>
+                       </layout>
+                      </widget>
+                      <widget class="QWidget" name="page_4">
+                       <attribute name="label">
+                        <string>Snapshots</string>
+                       </attribute>
+                       <layout class="QVBoxLayout" name="verticalLayout_8">
+                        <item>
+                         <layout class="QVBoxLayout" name="verticalLayout_10">
+                          <item>
+                           <layout class="QHBoxLayout" name="horizontalLayout_2">
+                            <item>
+                             <widget class="QLabel" name="snapshotLabel_3">
+                              <property name="text">
+                               <string>File name</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="QLineEdit" name="filePrefixSnapshotsLineEdit">
+                              <property name="toolTip">
+                               <string>File prefix used to prepend to anapshot file names</string>
+                              </property>
+                              <property name="text">
+                               <string/>
+                              </property>
+                              <property name="placeholderText">
+                               <string/>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </item>
+                          <item>
+                           <layout class="QHBoxLayout" name="horizontalLayout_4">
+                            <item>
+                             <widget class="QPushButton" name="snapshotButton">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="toolTip">
+                               <string>Record specified number of individual images on base folder</string>
+                              </property>
+                              <property name="styleSheet">
+                               <string notr="true"/>
+                              </property>
+                              <property name="text">
+                               <string>Record snapshots</string>
+                              </property>
+                              <property name="icon">
+                               <iconset>
+                                <normaloff>resources/play-button.png</normaloff>resources/play-button.png</iconset>
+                              </property>
+                              <property name="checkable">
+                               <bool>false</bool>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="QSpinBox" name="nSnapshotsSpinBox">
+                              <property name="toolTip">
+                               <string>Number of snapshots to record</string>
+                              </property>
+                              <property name="maximum">
+                               <number>100</number>
+                              </property>
+                              <property name="value">
+                               <number>1</number>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </item>
+                          <item>
+                           <spacer name="verticalSpacer">
+                            <property name="orientation">
+                             <enum>Qt::Vertical</enum>
+                            </property>
+                            <property name="sizeHint" stdset="0">
+                             <size>
+                              <width>20</width>
+                              <height>40</height>
+                             </size>
+                            </property>
+                           </spacer>
+                          </item>
+                         </layout>
                         </item>
                        </layout>
                       </widget>
@@ -758,158 +849,6 @@
             </item>
            </layout>
           </widget>
-          <widget class="QWidget" name="extrasTab">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Extra controls like snapshots recordings</string>
-           </property>
-           <attribute name="title">
-            <string>Snapshots</string>
-           </attribute>
-           <layout class="QHBoxLayout" name="horizontalLayout_10">
-            <item>
-             <layout class="QVBoxLayout" name="extrasVerticalLayout">
-              <property name="sizeConstraint">
-               <enum>QLayout::SetDefaultConstraint</enum>
-              </property>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_12">
-                <item>
-                 <widget class="QLabel" name="extrasSubFolderQLabel">
-                  <property name="text">
-                   <string>Sub folder</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="subFolderExtrasLineEdit">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="toolTip">
-                   <string>Sub folder where extra recordings (e.g. snapshots) will be stored</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="placeholderText">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_3">
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="snapshotLabel_3">
-                  <property name="text">
-                   <string>File name</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="filePrefixExtrasLineEdit">
-                  <property name="toolTip">
-                   <string>File prefix used to prepend to anapshot file names</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="placeholderText">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_6">
-                <item>
-                 <widget class="QPushButton" name="snapshotButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>Record specified number of individual images on base folder</string>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true"/>
-                  </property>
-                  <property name="text">
-                   <string>Record snapshots</string>
-                  </property>
-                  <property name="icon">
-                   <iconset>
-                    <normaloff>resources/play-button.png</normaloff>resources/play-button.png</iconset>
-                  </property>
-                  <property name="checkable">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QSpinBox" name="nSnapshotsSpinBox">
-                  <property name="toolTip">
-                   <string>Number of snapshots to record</string>
-                  </property>
-                  <property name="maximum">
-                   <number>100</number>
-                  </property>
-                  <property name="value">
-                   <number>1</number>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_5">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <spacer name="verticalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
           <widget class="QWidget" name="viewerTab">
            <attribute name="title">
             <string>Viewer</string>
@@ -968,7 +907,7 @@
          </widget>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="0,1,1">
+         <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="0,1,1,0,0">
           <property name="spacing">
            <number>0</number>
           </property>
@@ -1084,6 +1023,16 @@
              <set>QPainter::Antialiasing|QPainter::SmoothPixmapTransform</set>
             </property>
            </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6"/>
           </item>
          </layout>
         </item>
@@ -1259,9 +1208,6 @@
   <tabstop>exposureSlider</tabstop>
   <tabstop>logTextEdit</tabstop>
   <tabstop>logTextLineEdit</tabstop>
-  <tabstop>subFolderExtrasLineEdit</tabstop>
-  <tabstop>snapshotButton</tabstop>
-  <tabstop>nSnapshotsSpinBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -42,9 +42,15 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>450</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="maximumSize">
            <size>
-            <width>800</width>
+            <width>600</width>
             <height>16777215</height>
            </size>
           </property>
@@ -86,11 +92,14 @@
             <item>
              <layout class="QVBoxLayout" name="verticalLayout">
               <item>
-               <layout class="QHBoxLayout" name="mainUiHorizontalLayout" stretch="3,1,0">
+               <layout class="QHBoxLayout" name="mainUiHorizontalLayout" stretch="3,1">
                 <item>
                  <layout class="QVBoxLayout" name="mainControlsVerticalLayout" stretch="0,0">
                   <property name="sizeConstraint">
                    <enum>QLayout::SetDefaultConstraint</enum>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
                   </property>
                   <item>
                    <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,8">
@@ -150,7 +159,7 @@
                    </layout>
                   </item>
                   <item>
-                   <layout class="QVBoxLayout" name="mainUiVerticalLayout" stretch="0,0,0">
+                   <layout class="QVBoxLayout" name="mainUiVerticalLayout" stretch="0,0,0,0,0,0">
                     <item>
                      <widget class="QToolBox" name="videoToolBox">
                       <property name="sizePolicy">
@@ -176,7 +185,7 @@
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>368</width>
+                         <width>513</width>
                          <height>247</height>
                         </rect>
                        </property>
@@ -362,8 +371,8 @@
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>368</width>
-                         <height>230</height>
+                         <width>513</width>
+                         <height>121</height>
                         </rect>
                        </property>
                        <attribute name="label">
@@ -457,8 +466,8 @@
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>368</width>
-                         <height>230</height>
+                         <width>513</width>
+                         <height>185</height>
                         </rect>
                        </property>
                        <attribute name="label">
@@ -586,8 +595,8 @@
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>368</width>
-                         <height>230</height>
+                         <width>513</width>
+                         <height>127</height>
                         </rect>
                        </property>
                        <attribute name="label">
@@ -683,58 +692,7 @@
                      </widget>
                     </item>
                     <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_8">
-                      <item>
-                       <spacer name="horizontalSpacer_4">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                      <item>
-                       <widget class="QLCDNumber" name="timerLCDNumber">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>150</width>
-                          <height>60</height>
-                         </size>
-                        </property>
-                        <property name="toolTip">
-                         <string>Time elapsed while recording</string>
-                        </property>
-                        <property name="frameShadow">
-                         <enum>QFrame::Raised</enum>
-                        </property>
-                        <property name="smallDecimalPoint">
-                         <bool>false</bool>
-                        </property>
-                        <property name="digitCount">
-                         <number>8</number>
-                        </property>
-                        <property name="mode">
-                         <enum>QLCDNumber::Dec</enum>
-                        </property>
-                        <property name="segmentStyle">
-                         <enum>QLCDNumber::Flat</enum>
-                        </property>
-                        <property name="value" stdset="0">
-                         <double>0.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
+                     <layout class="QHBoxLayout" name="horizontalLayout_8"/>
                     </item>
                     <item>
                      <spacer name="verticalSpacer_2">
@@ -748,6 +706,63 @@
                        </size>
                       </property>
                      </spacer>
+                    </item>
+                    <item>
+                     <widget class="QTextEdit" name="logTextEdit">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>200</width>
+                        <height>200</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>16777215</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="toolTip">
+                       <string>Logged messages</string>
+                      </property>
+                      <property name="sizeAdjustPolicy">
+                       <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+                      </property>
+                      <property name="readOnly">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="messageLogLabel">
+                      <property name="text">
+                       <string>Message log </string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="logTextLineEdit">
+                      <property name="toolTip">
+                       <string>Write mesage to be logged and hit return key</string>
+                      </property>
+                      <property name="inputMask">
+                       <string/>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                      <property name="placeholderText">
+                       <string/>
+                      </property>
+                     </widget>
                     </item>
                    </layout>
                   </item>
@@ -783,73 +798,6 @@
                    <number>10</number>
                   </property>
                  </widget>
-                </item>
-                <item>
-                 <layout class="QVBoxLayout" name="verticalLayout_3" stretch="2,0,0">
-                  <property name="spacing">
-                   <number>6</number>
-                  </property>
-                  <property name="sizeConstraint">
-                   <enum>QLayout::SetDefaultConstraint</enum>
-                  </property>
-                  <item>
-                   <widget class="QTextEdit" name="logTextEdit">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>200</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="toolTip">
-                     <string>Logged messages</string>
-                    </property>
-                    <property name="sizeAdjustPolicy">
-                     <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-                    </property>
-                    <property name="readOnly">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="messageLogLabel">
-                    <property name="text">
-                     <string>Message log </string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QLineEdit" name="logTextLineEdit">
-                    <property name="toolTip">
-                     <string>Write mesage to be logged and hit return key</string>
-                    </property>
-                    <property name="inputMask">
-                     <string/>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="placeholderText">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
                 </item>
                </layout>
               </item>
@@ -915,7 +863,7 @@
          </widget>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="0,1,1,0,0">
+         <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="0,1,1">
           <property name="spacing">
            <number>0</number>
           </property>
@@ -1032,16 +980,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6"/>
-          </item>
          </layout>
         </item>
        </layout>
@@ -1062,6 +1000,16 @@
       </item>
       <item>
        <layout class="QHBoxLayout" name="statusHorizontalLayout">
+        <item>
+         <widget class="QLabel" name="temperatureNameLabel">
+          <property name="text">
+           <string>Temperature:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
         <item>
          <widget class="QLCDNumber" name="temperatureLCDNumber">
           <property name="toolTip">
@@ -1085,7 +1033,7 @@
         <item>
          <widget class="QLabel" name="overexposureLabel">
           <property name="text">
-           <string>overexp:</string>
+           <string>Overexp:</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1115,7 +1063,7 @@
         <item>
          <widget class="QLabel" name="underexposureLabel">
           <property name="text">
-           <string>underexp:</string>
+           <string>Underexp:</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1197,6 +1145,53 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QLabel" name="timeLabel">
+          <property name="text">
+           <string>Time:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLCDNumber" name="timerLCDNumber">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Time elapsed while recording</string>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
+          </property>
+          <property name="smallDecimalPoint">
+           <bool>false</bool>
+          </property>
+          <property name="digitCount">
+           <number>8</number>
+          </property>
+          <property name="mode">
+           <enum>QLCDNumber::Dec</enum>
+          </property>
+          <property name="segmentStyle">
+           <enum>QLCDNumber::Flat</enum>
+          </property>
+          <property name="value" stdset="0">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
@@ -1214,8 +1209,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>exposureSlider</tabstop>
-  <tabstop>logTextEdit</tabstop>
-  <tabstop>logTextLineEdit</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -26,7 +26,7 @@
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
-   <layout class="QHBoxLayout" name="horizontalLayout_3">
+   <layout class="QVBoxLayout" name="verticalLayout_4">
     <item>
      <layout class="QVBoxLayout" name="mainVerticalLayout">
       <item>
@@ -49,7 +49,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Extra recording controls e.g. snapshots</string>
+           <string/>
           </property>
           <property name="tabPosition">
            <enum>QTabWidget::West</enum>
@@ -80,20 +80,20 @@
             <string/>
            </property>
            <attribute name="title">
-            <string>Recording</string>
+            <string>Video</string>
            </attribute>
            <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
              <layout class="QVBoxLayout" name="verticalLayout">
               <item>
-               <layout class="QHBoxLayout" name="mainUiHorizontalLayout" stretch="0,1,0">
+               <layout class="QHBoxLayout" name="mainUiHorizontalLayout" stretch="3,1,0">
                 <item>
-                 <layout class="QVBoxLayout" name="mainControlsVerticalLayout" stretch="0,12">
+                 <layout class="QVBoxLayout" name="mainControlsVerticalLayout" stretch="0,0">
                   <property name="sizeConstraint">
                    <enum>QLayout::SetDefaultConstraint</enum>
                   </property>
                   <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_9">
+                   <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,8">
                     <property name="topMargin">
                      <number>0</number>
                     </property>
@@ -103,7 +103,7 @@
                        <bool>true</bool>
                       </property>
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
@@ -112,6 +112,12 @@
                        <size>
                         <width>20</width>
                         <height>20</height>
+                       </size>
+                      </property>
+                      <property name="sizeIncrement">
+                       <size>
+                        <width>1</width>
+                        <height>1</height>
                        </size>
                       </property>
                       <property name="toolTip">
@@ -144,261 +150,453 @@
                    </layout>
                   </item>
                   <item>
-                   <layout class="QVBoxLayout" name="mainUiVerticalLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+                   <layout class="QVBoxLayout" name="mainUiVerticalLayout" stretch="0,0,0">
                     <item>
-                     <widget class="Line" name="fileNameSeparatorLine">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_4">
-                      <item>
-                       <widget class="QPushButton" name="baseFolderButton">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="toolTip">
-                         <string>Select folder where all data is organized</string>
-                        </property>
-                        <property name="text">
-                         <string>Save folder</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLineEdit" name="baseFolderLineEdit">
-                        <property name="toolTip">
-                         <string>Folder where all data is stored</string>
-                        </property>
-                        <property name="readOnly">
-                         <bool>false</bool>
-                        </property>
-                        <property name="placeholderText">
-                         <string>Base folder where all data is stored</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_11">
-                      <item>
-                       <widget class="QLabel" name="filePrefixLabel">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="toolTip">
-                         <string>File name</string>
-                        </property>
-                        <property name="text">
-                         <string>File Name</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLineEdit" name="filePrefixLineEdit">
-                        <property name="toolTip">
-                         <string>Prefix appended to the beginning each file stored</string>
-                        </property>
-                        <property name="text">
-                         <string/>
-                        </property>
-                        <property name="placeholderText">
-                         <string>file1, file2, ...</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="recordButton">
+                     <widget class="QToolBox" name="videoToolBox">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
                       </property>
-                      <property name="toolTip">
-                       <string>Press to start / stop recording</string>
+                      <property name="minimumSize">
+                       <size>
+                        <width>0</width>
+                        <height>0</height>
+                       </size>
                       </property>
-                      <property name="autoFillBackground">
-                       <bool>false</bool>
+                      <property name="frameShape">
+                       <enum>QFrame::NoFrame</enum>
                       </property>
-                      <property name="styleSheet">
-                       <string notr="true"/>
+                      <property name="currentIndex">
+                       <number>0</number>
                       </property>
-                      <property name="text">
-                       <string>Record video</string>
-                      </property>
-                      <property name="icon">
-                       <iconset>
-                        <normaloff>resources/play-button.png</normaloff>resources/play-button.png</iconset>
-                      </property>
-                      <property name="checkable">
-                       <bool>true</bool>
-                      </property>
+                      <widget class="QWidget" name="page">
+                       <property name="geometry">
+                        <rect>
+                         <x>0</x>
+                         <y>0</y>
+                         <width>368</width>
+                         <height>261</height>
+                        </rect>
+                       </property>
+                       <attribute name="label">
+                        <string>File management</string>
+                       </attribute>
+                       <layout class="QVBoxLayout" name="verticalLayout_5">
+                        <item>
+                         <layout class="QFormLayout" name="formLayout">
+                          <property name="sizeConstraint">
+                           <enum>QLayout::SetDefaultConstraint</enum>
+                          </property>
+                          <property name="labelAlignment">
+                           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                          </property>
+                          <property name="formAlignment">
+                           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                          </property>
+                          <item row="0" column="0">
+                           <widget class="QPushButton" name="baseFolderButton">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="toolTip">
+                             <string>Select folder where all data is organized</string>
+                            </property>
+                            <property name="text">
+                             <string>Save folder</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item row="0" column="1">
+                           <widget class="QLineEdit" name="baseFolderLineEdit">
+                            <property name="toolTip">
+                             <string>Folder where all data is stored</string>
+                            </property>
+                            <property name="styleSheet">
+                             <string notr="true"/>
+                            </property>
+                            <property name="readOnly">
+                             <bool>false</bool>
+                            </property>
+                            <property name="placeholderText">
+                             <string/>
+                            </property>
+                           </widget>
+                          </item>
+                          <item row="1" column="0">
+                           <widget class="QLabel" name="filePrefixLabel">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="toolTip">
+                             <string>File name</string>
+                            </property>
+                            <property name="text">
+                             <string>File Name</string>
+                            </property>
+                            <property name="alignment">
+                             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                            </property>
+                           </widget>
+                          </item>
+                          <item row="1" column="1">
+                           <widget class="QLineEdit" name="filePrefixLineEdit">
+                            <property name="toolTip">
+                             <string>Prefix appended to the beginning each file stored</string>
+                            </property>
+                            <property name="text">
+                             <string/>
+                            </property>
+                            <property name="placeholderText">
+                             <string/>
+                            </property>
+                           </widget>
+                          </item>
+                          <item row="2" column="0">
+                           <widget class="QLabel" name="skipFramesLabel">
+                            <property name="text">
+                             <string>Skip frames</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item row="2" column="1">
+                           <widget class="QSpinBox" name="skipFramesSpinBox">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="toolTip">
+                             <string>Time to wait between consecutive recording frames</string>
+                            </property>
+                            <property name="toolTipDuration">
+                             <number>5</number>
+                            </property>
+                            <property name="maximum">
+                             <number>1000</number>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
+                        </item>
+                        <item>
+                         <widget class="QPushButton" name="recordButton">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="toolTip">
+                           <string>Press to start / stop recording</string>
+                          </property>
+                          <property name="autoFillBackground">
+                           <bool>false</bool>
+                          </property>
+                          <property name="styleSheet">
+                           <string notr="true"/>
+                          </property>
+                          <property name="text">
+                           <string>Record video</string>
+                          </property>
+                          <property name="icon">
+                           <iconset>
+                            <normaloff>resources/play-button.png</normaloff>resources/play-button.png</iconset>
+                          </property>
+                          <property name="checkable">
+                           <bool>true</bool>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QPushButton" name="darkCorrectionButton">
+                          <property name="enabled">
+                           <bool>true</bool>
+                          </property>
+                          <property name="toolTip">
+                           <string>Record dark reference images</string>
+                          </property>
+                          <property name="text">
+                           <string>Record dark reference</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QPushButton" name="whiteBalanceButton">
+                          <property name="enabled">
+                           <bool>true</bool>
+                          </property>
+                          <property name="toolTip">
+                           <string>Record white reference images</string>
+                          </property>
+                          <property name="text">
+                           <string>Record white reference</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="verticalSpacer_5">
+                          <property name="orientation">
+                           <enum>Qt::Vertical</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>20</width>
+                            <height>40</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
+                      </widget>
+                      <widget class="QWidget" name="page_2">
+                       <property name="geometry">
+                        <rect>
+                         <x>0</x>
+                         <y>0</y>
+                         <width>368</width>
+                         <height>261</height>
+                        </rect>
+                       </property>
+                       <attribute name="label">
+                        <string>Exposure</string>
+                       </attribute>
+                       <layout class="QVBoxLayout" name="verticalLayout_6">
+                        <item>
+                         <layout class="QHBoxLayout" name="horizontalLayout">
+                          <item>
+                           <widget class="QLabel" name="exposureLabel">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="text">
+                             <string>Exposure [ms]:</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="QLabel" name="hzLabel">
+                            <property name="text">
+                             <string>25</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="QLabel" name="hzPlaceholderLabel">
+                            <property name="text">
+                             <string>Hz</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <spacer name="horizontalSpacer_2">
+                            <property name="orientation">
+                             <enum>Qt::Horizontal</enum>
+                            </property>
+                            <property name="sizeHint" stdset="0">
+                             <size>
+                              <width>40</width>
+                              <height>20</height>
+                             </size>
+                            </property>
+                           </spacer>
+                          </item>
+                          <item>
+                           <widget class="QSpinBox" name="exposureSpinBox">
+                            <property name="minimum">
+                             <number>5</number>
+                            </property>
+                            <property name="maximum">
+                             <number>500</number>
+                            </property>
+                            <property name="value">
+                             <number>40</number>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
+                        </item>
+                        <item>
+                         <widget class="QCheckBox" name="autoexposureCheckbox">
+                          <property name="toolTip">
+                           <string>Select to adjust exposure automatically</string>
+                          </property>
+                          <property name="text">
+                           <string>Autoexposure</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="verticalSpacer_4">
+                          <property name="orientation">
+                           <enum>Qt::Vertical</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>20</width>
+                            <height>40</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
+                      </widget>
+                      <widget class="QWidget" name="page_3">
+                       <property name="geometry">
+                        <rect>
+                         <x>0</x>
+                         <y>0</y>
+                         <width>368</width>
+                         <height>261</height>
+                        </rect>
+                       </property>
+                       <attribute name="label">
+                        <string>Display</string>
+                       </attribute>
+                       <layout class="QVBoxLayout" name="verticalLayout_7">
+                        <item>
+                         <widget class="QCheckBox" name="normalizeCheckbox">
+                          <property name="toolTip">
+                           <string>Select to normalize displayed images</string>
+                          </property>
+                          <property name="text">
+                           <string>Histogram normalization</string>
+                          </property>
+                          <property name="checked">
+                           <bool>false</bool>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QLabel" name="displayedBandLabel">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>Image channel</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QSliderLabeled" name="bandSlider">
+                          <property name="toolTip">
+                           <string>Select displayed spectral band</string>
+                          </property>
+                          <property name="autoFillBackground">
+                           <bool>false</bool>
+                          </property>
+                          <property name="minimum">
+                           <number>1</number>
+                          </property>
+                          <property name="maximum">
+                           <number>16</number>
+                          </property>
+                          <property name="pageStep">
+                           <number>1</number>
+                          </property>
+                          <property name="value">
+                           <number>10</number>
+                          </property>
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="invertedAppearance">
+                           <bool>false</bool>
+                          </property>
+                          <property name="tickPosition">
+                           <enum>QSlider::TicksBelow</enum>
+                          </property>
+                          <property name="tickInterval">
+                           <number>1</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QLabel" name="rgbNormLabel">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>RGB norm factor</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QSliderLabeled" name="rgbNormSlider">
+                          <property name="toolTip">
+                           <string>Select the normalizing factor for RGB noormalization</string>
+                          </property>
+                          <property name="minimum">
+                           <number>1</number>
+                          </property>
+                          <property name="maximum">
+                           <number>30</number>
+                          </property>
+                          <property name="pageStep">
+                           <number>1</number>
+                          </property>
+                          <property name="value">
+                           <number>5</number>
+                          </property>
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="tickPosition">
+                           <enum>QSlider::TicksBelow</enum>
+                          </property>
+                          <property name="tickInterval">
+                           <number>1</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="verticalSpacer_3">
+                          <property name="orientation">
+                           <enum>Qt::Vertical</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>20</width>
+                            <height>40</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
+                      </widget>
                      </widget>
-                    </item>
-                    <item>
-                     <widget class="Line" name="referenceButtonsSeparatorLine">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="darkCorrectionButton">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                      <property name="toolTip">
-                       <string>Record dark reference images</string>
-                      </property>
-                      <property name="text">
-                       <string>Record dark reference</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="whiteBalanceButton">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                      <property name="toolTip">
-                       <string>Record white reference images</string>
-                      </property>
-                      <property name="text">
-                       <string>Record white reference</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="Line" name="exposureSeparatorLine">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout">
-                      <item>
-                       <widget class="QLabel" name="exposureLabel">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Exposure [ms]:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLineEdit" name="exposureLineEdit">
-                        <property name="toolTip">
-                         <string>Integration time in milliseconds used for each image</string>
-                        </property>
-                        <property name="text">
-                         <string>40</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="hzLabel">
-                        <property name="text">
-                         <string>25</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="hzPlaceholderLabel">
-                        <property name="text">
-                         <string>Hz</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="Line" name="skipFramesSeparatorLine">
-                        <property name="orientation">
-                         <enum>Qt::Vertical</enum>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="skipFramesLabel">
-                        <property name="text">
-                         <string>Skip frames:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QSpinBox" name="skipFramesSpinBox">
-                        <property name="toolTip">
-                         <string>Time to wait between consecutive recording frames</string>
-                        </property>
-                        <property name="toolTipDuration">
-                         <number>5</number>
-                        </property>
-                        <property name="maximum">
-                         <number>10000</number>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
                     </item>
                     <item>
                      <layout class="QHBoxLayout" name="horizontalLayout_8">
                       <item>
-                       <widget class="QCheckBox" name="normalizeCheckbox">
-                        <property name="toolTip">
-                         <string>Select to normalize displayed images</string>
-                        </property>
-                        <property name="text">
-                         <string>Normalize</string>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QCheckBox" name="autoexposureCheckbox">
-                        <property name="toolTip">
-                         <string>Select to adjust exposure automatically</string>
-                        </property>
-                        <property name="text">
-                         <string>Autoexposure</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="Line" name="timeSeparatorLine">
+                       <spacer name="horizontalSpacer_4">
                         <property name="orientation">
-                         <enum>Qt::Vertical</enum>
+                         <enum>Qt::Horizontal</enum>
                         </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="timeLabel">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
                         </property>
-                        <property name="text">
-                         <string>Time recording:</string>
-                        </property>
-                       </widget>
+                       </spacer>
                       </item>
                       <item>
                        <widget class="QLCDNumber" name="timerLCDNumber">
@@ -410,7 +608,7 @@
                         </property>
                         <property name="minimumSize">
                          <size>
-                          <width>0</width>
+                          <width>150</width>
                           <height>60</height>
                          </size>
                         </property>
@@ -438,94 +636,6 @@
                        </widget>
                       </item>
                      </layout>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="rgbNormLabel">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Select RGB norm:</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSliderLabeled" name="rgbNormSlider">
-                      <property name="toolTip">
-                       <string>Select the normalizing factor for RGB noormalization</string>
-                      </property>
-                      <property name="minimum">
-                       <number>1</number>
-                      </property>
-                      <property name="maximum">
-                       <number>30</number>
-                      </property>
-                      <property name="pageStep">
-                       <number>1</number>
-                      </property>
-                      <property name="value">
-                       <number>5</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>1</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="displayedBandLabel">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Select channel:</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSliderLabeled" name="bandSlider">
-                      <property name="toolTip">
-                       <string>Select displayed spectral band</string>
-                      </property>
-                      <property name="autoFillBackground">
-                       <bool>false</bool>
-                      </property>
-                      <property name="minimum">
-                       <number>1</number>
-                      </property>
-                      <property name="maximum">
-                       <number>16</number>
-                      </property>
-                      <property name="pageStep">
-                       <number>1</number>
-                      </property>
-                      <property name="value">
-                       <number>10</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="invertedAppearance">
-                       <bool>false</bool>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>1</number>
-                      </property>
-                     </widget>
                     </item>
                     <item>
                      <spacer name="verticalSpacer_2">
@@ -627,7 +737,7 @@
                   <item>
                    <widget class="QLineEdit" name="logTextLineEdit">
                     <property name="toolTip">
-                     <string/>
+                     <string>Write mesage to be logged and hit return key</string>
                     </property>
                     <property name="inputMask">
                      <string/>
@@ -636,7 +746,7 @@
                      <string/>
                     </property>
                     <property name="placeholderText">
-                     <string>Write message to be logged</string>
+                     <string/>
                     </property>
                    </widget>
                   </item>
@@ -665,7 +775,7 @@
             <string>Extra controls like snapshots recordings</string>
            </property>
            <attribute name="title">
-            <string>Extras</string>
+            <string>Snapshots</string>
            </attribute>
            <layout class="QHBoxLayout" name="horizontalLayout_10">
             <item>
@@ -674,11 +784,58 @@
                <enum>QLayout::SetDefaultConstraint</enum>
               </property>
               <item>
-               <widget class="QLabel" name="lowExposureLabel">
-                <property name="text">
-                 <string>Extras like snapshots recording controls</string>
+               <layout class="QHBoxLayout" name="horizontalLayout_12">
+                <item>
+                 <widget class="QLabel" name="extrasSubFolderQLabel">
+                  <property name="text">
+                   <string>Sub folder</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="subFolderExtrasLineEdit">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="toolTip">
+                   <string>Sub folder where extra recordings (e.g. snapshots) will be stored</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="placeholderText">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_3">
+                <property name="topMargin">
+                 <number>0</number>
                 </property>
-               </widget>
+                <item>
+                 <widget class="QLabel" name="snapshotLabel_3">
+                  <property name="text">
+                   <string>File name</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="filePrefixExtrasLineEdit">
+                  <property name="toolTip">
+                   <string>File prefix used to prepend to anapshot file names</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="placeholderText">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -714,66 +871,25 @@
                    <string>Number of snapshots to record</string>
                   </property>
                   <property name="maximum">
-                   <number>999</number>
+                   <number>100</number>
                   </property>
                   <property name="value">
                    <number>1</number>
                   </property>
                  </widget>
                 </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="Line" name="subFolderExtrasSeparatorLine">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_12">
                 <item>
-                 <widget class="QLabel" name="extrasSubFolderQLabel">
-                  <property name="text">
-                   <string>Sub folder</string>
+                 <spacer name="horizontalSpacer_5">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
                   </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="subFolderExtrasLineEdit">
-                  <property name="enabled">
-                   <bool>true</bool>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
                   </property>
-                  <property name="toolTip">
-                   <string>Sub folder where extra recordings (e.g. snapshots) will be stored</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="placeholderText">
-                   <string>Sub folder to store extra recordings like snapshot images</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="snapshotLabel_3">
-                  <property name="text">
-                   <string>File prefix</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="filePrefixExtrasLineEdit">
-                  <property name="toolTip">
-                   <string>File prefix used to prepend to anapshot file names</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="placeholderText">
-                   <string>File prefix to append to each stored file</string>
-                  </property>
-                 </widget>
+                 </spacer>
                 </item>
                </layout>
               </item>
@@ -812,8 +928,11 @@
                 </item>
                 <item>
                  <widget class="QLineEdit" name="viewerFileLineEdit">
-                  <property name="placeholderText">
+                  <property name="toolTip">
                    <string>Path to .b2nd file</string>
+                  </property>
+                  <property name="placeholderText">
+                   <string/>
                   </property>
                  </widget>
                 </item>
@@ -823,6 +942,9 @@
                <widget class="QSliderLabeled" name="viewerImageSlider">
                 <property name="enabled">
                  <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Image index</string>
                 </property>
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -1134,23 +1256,10 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>filePrefixLineEdit</tabstop>
-  <tabstop>baseFolderButton</tabstop>
-  <tabstop>baseFolderLineEdit</tabstop>
-  <tabstop>recordButton</tabstop>
-  <tabstop>darkCorrectionButton</tabstop>
-  <tabstop>whiteBalanceButton</tabstop>
-  <tabstop>exposureLineEdit</tabstop>
-  <tabstop>skipFramesSpinBox</tabstop>
-  <tabstop>normalizeCheckbox</tabstop>
-  <tabstop>autoexposureCheckbox</tabstop>
-  <tabstop>rgbNormSlider</tabstop>
-  <tabstop>bandSlider</tabstop>
   <tabstop>exposureSlider</tabstop>
   <tabstop>logTextEdit</tabstop>
   <tabstop>logTextLineEdit</tabstop>
   <tabstop>subFolderExtrasLineEdit</tabstop>
-  <tabstop>filePrefixExtrasLineEdit</tabstop>
   <tabstop>snapshotButton</tabstop>
   <tabstop>nSnapshotsSpinBox</tabstop>
  </tabstops>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -169,7 +169,7 @@
                        <enum>QFrame::NoFrame</enum>
                       </property>
                       <property name="currentIndex">
-                       <number>3</number>
+                       <number>0</number>
                       </property>
                       <widget class="QWidget" name="page">
                        <property name="geometry">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -794,6 +794,55 @@
             </item>
            </layout>
           </widget>
+          <widget class="QWidget" name="viewerTab">
+           <attribute name="title">
+            <string>Viewer</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <layout class="QVBoxLayout" name="viewerVerticalLayout">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <item>
+                 <widget class="QPushButton" name="viewerFileButton">
+                  <property name="text">
+                   <string>Select File</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="viewerFileLineEdit">
+                  <property name="placeholderText">
+                   <string>Path to .b2nd file</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QSliderLabeled" name="viewerImageSlider">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGraphicsView" name="viewerGraphicsView">
+                <property name="minimumSize">
+                 <size>
+                  <width>512</width>
+                  <height>272</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
         <item>
@@ -1081,7 +1130,7 @@
   <customwidget>
    <class>QSliderLabeled</class>
    <extends>QSlider</extends>
-   <header>widgets.h</header>
+   <header location="global">widgets.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -22,7 +22,6 @@
 FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned int imageWidth)
 {
     this->filePath = strdup(filePath);
-    blosc2_init();
     blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
     cparams.typesize = sizeof(uint16_t);
     cparams.compcode = BLOSC_ZSTD;
@@ -60,7 +59,6 @@ FileImage::~FileImage()
     // free BLOSC resources
     b2nd_free(this->src);
     b2nd_free_ctx(this->ctx);
-    blosc2_destroy();
 }
 
 void FileImage::AppendMetadata()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -21,7 +21,7 @@
 
 FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned int imageWidth)
 {
-    this->filePath = strdup(filePath);
+    this->m_filePath = strdup(filePath);
     blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
     cparams.typesize = sizeof(uint16_t);
     cparams.compcode = BLOSC_ZSTD;
@@ -33,7 +33,7 @@ FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned in
     blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
     storage.contiguous = true;
     storage.cparams = &cparams;
-    storage.urlpath = this->filePath;
+    storage.urlpath = this->m_filePath;
 
     // Shape of the ndarray
     int64_t shape[] = {0, imageHeight, imageWidth};
@@ -41,15 +41,15 @@ FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned in
     int32_t chunk_shape[] = {1, static_cast<int>(imageHeight), static_cast<int>(imageWidth)};
     int32_t block_shape[] = {1, static_cast<int>(imageHeight), static_cast<int>(imageWidth)};
 
-    this->ctx = b2nd_create_ctx(&storage, 3, shape, chunk_shape, block_shape, "|u2", DTYPE_NUMPY_FORMAT, nullptr, 0);
+    this->m_ctx = b2nd_create_ctx(&storage, 3, shape, chunk_shape, block_shape, "|u2", DTYPE_NUMPY_FORMAT, nullptr, 0);
     int result;
-    if (access(this->filePath, F_OK) != -1)
+    if (access(this->m_filePath, F_OK) != -1)
     {
-        result = b2nd_open(this->filePath, &src);
+        result = b2nd_open(this->m_filePath, &m_src);
     }
     else
     {
-        result = b2nd_empty(this->ctx, &src);
+        result = b2nd_empty(this->m_ctx, &m_src);
     }
     HandleBLOSCResult(result, "b2nd_empty || b2nd_open");
 }
@@ -57,37 +57,37 @@ FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned in
 FileImage::~FileImage()
 {
     // free BLOSC resources
-    b2nd_free(this->src);
-    b2nd_free_ctx(this->ctx);
+    b2nd_free(this->m_src);
+    b2nd_free_ctx(this->m_ctx);
 }
 
 void FileImage::AppendMetadata()
 {
     // pack and append metadata
-    PackAndAppendMetadata(this->src, EXPOSURE_KEY, this->m_exposureMetadata);
-    PackAndAppendMetadata(this->src, FRAME_NUMBER_KEY, this->m_acqNframeMetadata);
-    PackAndAppendMetadata(this->src, COLOR_FILTER_ARRAY_FORMAT_KEY, this->m_colorFilterArray);
-    PackAndAppendMetadata(this->src, TIME_STAMP_KEY, this->m_timeStamp);
+    PackAndAppendMetadata(this->m_src, EXPOSURE_KEY, this->m_exposureMetadata);
+    PackAndAppendMetadata(this->m_src, FRAME_NUMBER_KEY, this->m_acqNframeMetadata);
+    PackAndAppendMetadata(this->m_src, COLOR_FILTER_ARRAY_FORMAT_KEY, this->m_colorFilterArray);
+    PackAndAppendMetadata(this->m_src, TIME_STAMP_KEY, this->m_timeStamp);
     for (const QString &key : m_additionalMetadata.keys())
     {
-        PackAndAppendMetadata(this->src, key.toUtf8().constData(), this->m_additionalMetadata[key]);
+        PackAndAppendMetadata(this->m_src, key.toUtf8().constData(), this->m_additionalMetadata[key]);
     }
     LOG_XILENS(info) << "Metadata was written to file";
 }
 
-void FileImage::write(XI_IMG image, QMap<QString, float> additionalMetadata)
+void FileImage::WriteImageData(XI_IMG image, QMap<QString, float> additionalMetadata)
 {
     const size_t buffer_size = static_cast<size_t>(image.width) * static_cast<size_t>(image.height) * sizeof(uint16_t);
     if (buffer_size > static_cast<size_t>(INT64_MAX))
     {
         throw std::overflow_error("Buffer size exceeds the maximum value of int64_t.");
     }
-    int result = b2nd_append(src, image.bp, static_cast<int64_t>(buffer_size), 0);
+    int result = b2nd_append(m_src, image.bp, static_cast<int64_t>(buffer_size), 0);
     HandleBLOSCResult(result, "b2nd_append");
     // store metadata
     this->m_exposureMetadata.emplace_back(image.exposure_time_us);
     this->m_acqNframeMetadata.emplace_back(image.acq_nframe);
-    this->m_colorFilterArray.emplace_back(colorFilterToString(image.color_filter_array));
+    this->m_colorFilterArray.emplace_back(ColorFilterToString(image.color_filter_array));
     this->m_timeStamp.emplace_back(GetTimeStamp().toStdString());
     for (const QString &key : additionalMetadata.keys())
     {
@@ -111,7 +111,7 @@ template <typename T> void PackAndAppendMetadata(b2nd_array_t *src, const char *
     }
 }
 
-std::string colorFilterToString(XI_COLOR_FILTER_ARRAY colorFilterArray)
+std::string ColorFilterToString(XI_COLOR_FILTER_ARRAY colorFilterArray)
 {
     switch (colorFilterArray)
     {
@@ -233,26 +233,9 @@ void AppendBLOSCVLMetadata(b2nd_array_t *src, const char *key, msgpack::sbuffer 
     }
 }
 
-void rescale(cv::Mat &mat, float high)
-{
-    double min, max;
-    cv::minMaxLoc(mat, &min, &max);
-    mat = (mat - ((float)min)) * high / ((float)max - min);
-}
-
-void clamp(cv::Mat &mat, cv::Range bounds)
-{
-    cv::min(cv::max(mat, bounds.start), bounds.end, mat);
-}
-
-void wait(int milliseconds)
+void WaitMilliseconds(int milliseconds)
 {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(milliseconds));
-}
-
-void initLogging(enum boost::log::trivial::severity_level severity)
-{
-    boost::log::core::get()->set_filter(boost::log::trivial::severity >= severity);
 }
 
 cv::Mat CreateLut(cv::Vec3b saturation_color, cv::Vec3b dark_color)

--- a/src/util.h
+++ b/src/util.h
@@ -88,17 +88,17 @@ class FileImage
     /**
      * path to file location
      */
-    char *filePath;
+    char *m_filePath;
 
     /**
      * Storage context
      */
-    b2nd_context_t *ctx;
+    b2nd_context_t *m_ctx;
 
     /**
      * Array storage created temporarily for BLOSC
      */
-    b2nd_array_t *src; // New member to store array
+    b2nd_array_t *m_src; // New member to store array
 
     /**
      * Opens a file and throws runtime error when opening fails
@@ -116,7 +116,7 @@ class FileImage
      * @param image Ximea image where data is stored
      * @param additionalMetadata Additional metadata to be stored in the array
      */
-    void write(XI_IMG image, QMap<QString, float> additionalMetadata);
+    void WriteImageData(XI_IMG image, QMap<QString, float> additionalMetadata);
 
     /**
      * Appends metadata to BLOSC ND array. This method should be called before
@@ -151,33 +151,13 @@ template <typename T> void PackAndAppendMetadata(b2nd_array_t *src, const char *
  * @param colorFilterArray XIMEA color filter array representation
  * @return string representing the color filter array
  */
-std::string colorFilterToString(XI_COLOR_FILTER_ARRAY colorFilterArray);
-
-/**
- * Initializes the logging by setting a severity
- * @param severity level of logging to set
- */
-void initLogging(enum boost::log::trivial::severity_level severity);
+std::string ColorFilterToString(XI_COLOR_FILTER_ARRAY colorFilterArray);
 
 /**
  * waits a certain amount of milliseconds on a boost thread
- * @param milliseconds amount of time to wait
+ * @param milliseconds amount of time to WaitMilliseconds
  */
-void wait(int milliseconds);
-
-/**
- * Restricts the values in a matrix to the range defined by bounds
- * @param mat matrix of values to restrict
- * @param bounds range of values
- */
-void clamp(cv::Mat &mat, cv::Range bounds);
-
-/**
- * Rescales values to a range defined by high, lower bound is always 0
- * @param mat matrix values to rescale
- * @param high maximum value that defines the range
- */
-void rescale(cv::Mat &mat, float high);
+void WaitMilliseconds(int milliseconds);
 
 /**
  * Created a look up table (LUT) that can be used to define the colors of pixels

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -17,7 +17,7 @@ QSliderLabeled::QSliderLabeled(QWidget *parent) : QSlider(parent)
 {
 }
 
-void QSliderLabeled::applyStyleSheet()
+void QSliderLabeled::ApplyStyleSheet()
 {
     QFontMetrics fm(font());
     QString maxLabel = QString::number(maximum());
@@ -106,23 +106,23 @@ void QSliderLabeled::mouseMoveEvent(QMouseEvent *event)
     QSlider::mouseMoveEvent(event);
 }
 
-void QSliderLabeled::updatePainterPen()
+void QSliderLabeled::UpdatePainterPen()
 {
     QColor penColor = isEnabled() ? QColor(255, 215, 64) : QColor(79, 91, 98);
     m_penColor = penColor;
 }
 
-void QSliderLabeled::setGrooveMargin(int value)
+void QSliderLabeled::SetGrooveMargin(int value)
 {
     m_grooveMargin = value;
 }
 
-void QSliderLabeled::setMaxNumberOfLabels(int value)
+void QSliderLabeled::SetMaxNumberOfLabels(int value)
 {
     m_maxNumberOfLabels = value;
 }
 
-void QSliderLabeled::setSliderSpread(int value)
+void QSliderLabeled::SetSliderSpread(int value)
 {
     m_sliderSpread = value;
 }

--- a/src/widgets.h
+++ b/src/widgets.h
@@ -36,20 +36,20 @@ class QSliderLabeled : public QSlider
      *
      * @param value
      */
-    void setGrooveMargin(int value);
+    void SetGrooveMargin(int value);
 
     /**
      * Sets Maximum number of labels to display in the slider.
      *
      * @param value maximum number of labels.
      */
-    void setMaxNumberOfLabels(int value);
+    void SetMaxNumberOfLabels(int value);
 
     /**
      * Applies a custom style sheet that defines the width and height of the slider based on the orientation
      * of the slider.
      */
-    void applyStyleSheet();
+    void ApplyStyleSheet();
 
     /**
      * Sets the maximum spread of the slider. This will represent the maximum height when slider is horizontal and
@@ -57,7 +57,7 @@ class QSliderLabeled : public QSlider
      *
      * @param value the slider spread.
      */
-    void setSliderSpread(int value);
+    void SetSliderSpread(int value);
 
   protected:
     /**
@@ -77,14 +77,14 @@ class QSliderLabeled : public QSlider
     void showEvent(QShowEvent *event) override
     {
         QSlider::showEvent(event);
-        applyStyleSheet();
+        ApplyStyleSheet();
     }
 
     /**
      * @brief Overrides the event() method from the parent class.
      *
      * This method is triggered when an event is received by the widget. It specifically handles the
-     * `QEvent::EnabledChange` event and calls the `updatePainterPen()` method to update the painter pen. It then calls
+     * `QEvent::EnabledChange` event and calls the `UpdatePainterPen()` method to update the painter pen. It then calls
      * the event() method of the parent class to handle any other events. Finally, it returns a boolean value indicating
      * whether the event was handled.
      *
@@ -95,7 +95,7 @@ class QSliderLabeled : public QSlider
     {
         if (e->type() == QEvent::EnabledChange)
         {
-            updatePainterPen();
+            UpdatePainterPen();
         }
         return QSlider::event(e);
     }
@@ -135,7 +135,7 @@ class QSliderLabeled : public QSlider
      * Updates the painter's pen color based on the enabled state of the QSliderLabeled widget.
      * The pen color is set to a specific color if the widget is enabled, and to a different color if it is disabled.
      */
-    void updatePainterPen();
+    void UpdatePainterPen();
 };
 
 #endif // XILENS_WIDGETS_H

--- a/tests/cameraInterfaceTest.cpp
+++ b/tests/cameraInterfaceTest.cpp
@@ -36,7 +36,7 @@ TEST(CameraInterfaceTest, StartAcquisition_InvalidHandle)
     std::shared_ptr<MockXiAPIWrapper> apiWrapper = std::make_shared<MockXiAPIWrapper>();
     CameraInterface cameraInterface;
     cameraInterface.m_apiWrapper = apiWrapper;
-    cameraInterface.setCamera(CAMERA_TYPE_SPECTRAL, CAMERA_FAMILY_XISPEC);
+    cameraInterface.SetCamera(CAMERA_TYPE_SPECTRAL, CAMERA_FAMILY_XISPEC);
     QString cameraIdentifier = "MockDeviceModel@MockSensorSN";
     cameraInterface.m_availableCameras[cameraIdentifier] = 0;
 
@@ -50,7 +50,7 @@ TEST(CameraInterfaceTest, StartAcquisition_StartSuccess)
     HANDLE cameraHandle;
     cameraInterface.m_cameraHandle = cameraHandle;
     cameraInterface.m_apiWrapper = apiWrapper;
-    cameraInterface.setCamera(CAMERA_TYPE_SPECTRAL, CAMERA_FAMILY_XISPEC);
+    cameraInterface.SetCamera(CAMERA_TYPE_SPECTRAL, CAMERA_FAMILY_XISPEC);
     QString cameraIdentifier = "MockDeviceModel@MockSensorSN";
     cameraInterface.m_availableCameras[cameraIdentifier] = 0;
 

--- a/tests/utilTest.cpp
+++ b/tests/utilTest.cpp
@@ -46,18 +46,6 @@ TEST(CreateLutTest, VerifyLutColorValues)
     }
 }
 
-TEST(RescaleTest, CheckValuesAfterRescaling)
-{
-    cv::Mat mat = (cv::Mat_<float>(3, 3) << 0.5, 1.2, 2.4, 3.2, 5.1, 6.3, 10.0, 20.0, 15.0);
-    rescale(mat, 100.0);
-    double min, max;
-    cv::minMaxLoc(mat, &min, &max);
-    EXPECT_GE(max, 0);
-    EXPECT_LE(max, 100);
-    EXPECT_GE(100, min);
-    EXPECT_LE(0, min);
-}
-
 TEST(XIIMGtoMatTest, MatDimensionsEqualToXIIMG)
 {
     XI_IMG xi_img;
@@ -99,7 +87,7 @@ TEST_F(FileImageWriteTest, CheckContentsAfterWriting)
     QMap<QString, float> additionalMetadata = {{"extraMetadata", 1.0}};
     for (int i = 0; i < nrImages; i++)
     {
-        fileImage.write(xiImage, additionalMetadata);
+        fileImage.WriteImageData(xiImage, additionalMetadata);
     }
     fileImage.AppendMetadata();
 
@@ -258,14 +246,14 @@ TEST_F(FileImageWriteTest, AppendMetadataTwice)
     QMap<QString, float> additionalMetadata = {{"extraMetadata", 1.0}};
     for (int i = 0; i < nrImages; i++)
     {
-        fileImage.write(xiImage, additionalMetadata);
+        fileImage.WriteImageData(xiImage, additionalMetadata);
     }
     fileImage.AppendMetadata();
 
     // append more images to the file
     for (int i = 0; i < nrImages; i++)
     {
-        fileImage.write(xiImage, additionalMetadata);
+        fileImage.WriteImageData(xiImage, additionalMetadata);
     }
     fileImage.AppendMetadata();
     blosc2_destroy();

--- a/tests/utilTest.cpp
+++ b/tests/utilTest.cpp
@@ -91,6 +91,8 @@ TEST_F(FileImageWriteTest, CheckContentsAfterWriting)
     xiImage.bp = malloc(static_cast<size_t>(xiImage.width) * static_cast<size_t>(xiImage.height) * sizeof(uint16_t));
     std::fill_n((uint16_t *)xiImage.bp, xiImage.width * xiImage.height, 12345);
     const char *urlpath = strdup("test_image.b2nd");
+
+    blosc2_init();
     blosc2_remove_urlpath(urlpath);
 
     FileImage fileImage(urlpath, xiImage.height, xiImage.width);
@@ -235,6 +237,7 @@ TEST_F(FileImageWriteTest, CheckContentsAfterWriting)
     }
     free(names);
     blosc2_remove_urlpath(urlpath);
+    blosc2_destroy();
 }
 
 TEST_F(FileImageWriteTest, AppendMetadataTwice)
@@ -247,6 +250,8 @@ TEST_F(FileImageWriteTest, AppendMetadataTwice)
     xiImage.bp = malloc(static_cast<size_t>(xiImage.width) * static_cast<size_t>(xiImage.height) * sizeof(uint16_t));
     std::fill_n((uint16_t *)xiImage.bp, xiImage.width * xiImage.height, 12345);
     const char *urlpath = strdup("test_image.b2nd");
+
+    blosc2_init();
     blosc2_remove_urlpath(urlpath);
 
     FileImage fileImage(urlpath, xiImage.height, xiImage.width);
@@ -263,4 +268,5 @@ TEST_F(FileImageWriteTest, AppendMetadataTwice)
         fileImage.write(xiImage, additionalMetadata);
     }
     fileImage.AppendMetadata();
+    blosc2_destroy();
 }


### PR DESCRIPTION
## Description
Adds a viewer tab to the UI to open recorded `.b2nd` files.

Summary of changes: 
### Added

- Adds image viewer tab to open recorded .b2nd files and scroll over images.
- Adds missing camera models to JSON file.

### Changed

- All displaying operations run from a thread, and only calls the main thread when the process images are to be displayed.
- Restructures UI for a more clear use and structures controls inside a toolbox.
- Limits frequency at which images are displayed to avoid locking the UI. Images are still recorded at full speed.

## Related Issue

#14 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
