### PR TITLE
37 spectral camera rgb channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All displaying operations run from a thread, and only calls the main thread when the process images are to be displayed.
 - Restructures UI for a more clear use and structures controls inside a toolbox.
 - Limits frequency at which images are displayed to avoid locking the UI. Images are still recorded at full speed.
+- Defines per-camera property to control which channels are used for rGB representation of the raw spectral data.
 
 ### Removed
 

--- a/resources/XiLensCameraProperties.json
+++ b/resources/XiLensCameraProperties.json
@@ -441,25 +441,113 @@
     "cameraType": "spectral",
     "cameraFamily": "xiSpec",
     "mosaicWidth": 4,
-    "mosaicHeight": 4
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
+  },
+  "MQ022HG-IM-SM4X4-VIS-FL": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
+  },
+  "MQ022HG-IM-SM4X4-VIS-FV": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
+  },
+  "MQ022HG-IM-SM4X4-VIS-FF": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
   },
   "MQ022HG-IM-SM5X5-NIR2": {
     "cameraType": "spectral",
     "cameraFamily": "xiSpec",
     "mosaicWidth": 5,
-    "mosaicHeight": 5
+    "mosaicHeight": 5,
+    "bgrChannels": [21, 12, 5]
+  },
+  "MQ022HG-IM-SM5X5-NIR2-FL": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 5,
+    "mosaicHeight": 5,
+    "bgrChannels": [21, 12, 5]
+  },
+  "MQ022HG-IM-SM5X5-NIR2-FV": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 5,
+    "mosaicHeight": 5,
+    "bgrChannels": [21, 12, 5]
+  },
+  "MQ022HG-IM-SM5X5-NIR2-FF": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 5,
+    "mosaicHeight": 5,
+    "bgrChannels": [21, 12, 5]
   },
   "MQ022HG-IM-SM4X4-RN2": {
     "cameraType": "spectral",
     "cameraFamily": "xiSpec",
     "mosaicWidth": 4,
-    "mosaicHeight": 4
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
+  },
+  "MQ022HG-IM-SM4X4-RN2-FL": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
+  },
+  "MQ022HG-IM-SM4X4-RN2-FV": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
+  },
+  "MQ022HG-IM-SM4X4-RN2-FF": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [11, 15, 3]
   },
   "MQ022HG-IM-SM4X4-VIS3": {
     "cameraType": "spectral",
     "cameraFamily": "xiSpec",
     "mosaicWidth": 4,
-    "mosaicHeight": 4
+    "mosaicHeight": 4,
+    "bgrChannels": [13, 6, 5]
+  },
+  "MQ022HG-IM-SM4X4-VIS3-FL": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [13, 6, 5]
+  },
+  "MQ022HG-IM-SM4X4-VIS3-FV": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [13, 6, 5]
+  },
+  "MQ022HG-IM-SM4X4-VIS3-FF": {
+    "cameraType": "spectral",
+    "cameraFamily": "xiSpec",
+    "mosaicWidth": 4,
+    "mosaicHeight": 4,
+    "bgrChannels": [13, 6, 5]
   },
   "MX022CG-CM": {
     "cameraType": "rgb",

--- a/src/constants.h
+++ b/src/constants.h
@@ -5,6 +5,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QMap>
 #include <QString>
@@ -129,6 +130,7 @@ struct CameraData
     QString cameraType;
     QString cameraFamily;
     std::vector<int> mosaicShape;
+    std::vector<int> bgrChannels;
 
     static CameraData fromJson(const QJsonObject &jsonObject)
     {
@@ -137,10 +139,36 @@ struct CameraData
         data.cameraFamily = jsonObject.value("cameraFamily").toString();
         data.mosaicShape.push_back(jsonObject.value("mosaicWidth").toInt());
         data.mosaicShape.push_back(jsonObject.value("mosaicHeight").toInt());
+        if (jsonObject.contains("bgrChannels") && jsonObject["bgrChannels"].isArray())
+        {
+            QJsonArray array = jsonObject["bgrChannels"].toArray();
+            for (const auto &entry : array)
+            {
+                data.bgrChannels.push_back(entry.toInt());
+            }
+        }
+        else
+        {
+            data.bgrChannels = std::vector<int>(); // Optional, but explicitly sets it as empty
+        }
         return data;
     }
 };
 
+/**
+ * Loads a camera mapper configuration from a JSON file.
+ *
+ * This function reads a JSON configuration file specified by the fileName
+ * and initializes a camera mapper based on the data within the file. The
+ * JSON file must adhere to the expected schema for this operation to
+ * succeed. The camera mapper configuration typically involves parameters
+ * such as camera mosaic shape, camera family, etc.
+ *
+ * @param fileName The path to the JSON file containing the camera mapper configuration.
+ *
+ * @return Returns true if the camera mapper configuration was successfully loaded,
+ *         false otherwise.
+ */
 QMap<QString, CameraData> loadCameraMapperFromJson(const QString &fileName);
 
 /**

--- a/src/displayFunctional.cpp
+++ b/src/displayFunctional.cpp
@@ -273,8 +273,19 @@ void DisplayerFunctional::ProcessImage(XI_IMG &image)
 
 void DisplayerFunctional::GetBGRImage(cv::Mat &image, cv::Mat &bgr_image)
 {
+    if (!getCameraMapper().contains(m_cameraModel))
+    {
+        LOG_XILENS(error) << "Could not find camera model in Mapper: " << m_cameraModel.toStdString();
+        throw std::runtime_error("Could not find camera in Mapper");
+    }
+    auto bgrChannels = getCameraMapper().value(m_cameraModel).bgrChannels;
+    if (bgrChannels.empty())
+    {
+        LOG_XILENS(error) << "Empty BGR channel indices";
+        throw std::runtime_error("Empty RGB channel indices");
+    }
     std::vector<cv::Mat> channels;
-    for (int i : m_BGRChannels)
+    for (int i : bgrChannels)
     {
         cv::Mat band_image = InitializeBandImage(image);
         this->GetBand(image, band_image, i);
@@ -307,5 +318,6 @@ void DisplayerFunctional::SetCameraProperties(QString cameraModel)
         throw std::runtime_error("Could not find camera in Mapper");
     }
     this->m_cameraType = getCameraMapper().value(cameraModel).cameraType;
+    this->m_cameraModel = cameraModel;
     this->m_mosaicShape = getCameraMapper().value(cameraModel).mosaicShape;
 }

--- a/src/displayFunctional.h
+++ b/src/displayFunctional.h
@@ -75,6 +75,11 @@ class DisplayerFunctional : public Displayer
     QString m_cameraType = CAMERA_TYPE_SPECTRAL;
 
     /**
+     * camera model used to identify camera properties.
+     */
+    QString m_cameraModel;
+
+    /**
      * Mosaic shape, particularly used for mosaic type cameras
      */
     std::vector<int> m_mosaicShape;
@@ -133,12 +138,6 @@ class DisplayerFunctional : public Displayer
      * Variable containing the data for the new image to be displayed.
      */
     XI_IMG m_nextImage{};
-
-    /**
-     * Vector with channel numbers that can be used to construct an approximate
-     * RGB image
-     */
-    std::vector<int> m_BGRChannels = {11, 15, 3};
 
     /**
      * Scaling factor used to convert image from 10bit to 8bit


### PR DESCRIPTION
## Description

Defines a property for the camera property JSON file to control which channels of the raw image are used to reconstruct a quasi-RGB image. These channels can be controlled form the JSON file now. 

## Related Issue

#37 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
