### PR TITLE
signal opencv matrix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Avoid Docker build freeze due to region selection
 ENV DEBIAN_FRONTEND=noninteractive
@@ -38,7 +38,6 @@ RUN dpkg -i xilens*.deb
 # run tests
 ENV QT_QPA_PLATFORM offscreen
 RUN xvfb-run -a --server-args="-screen 0 1024x768x24" ctest --output-on-failure
-RUN gcovr --html --exclude-unreachable-branches --print-summary -o coverage.html -e '/.*cmake-build.*/.*' --root ../
 
 # run application
-CMD QT_GRAPHICSSYSTEM="native" QT_X11_NO_MITSHM=1 /home/xilens/build/xilens /home/caffe/models/susi/imec_patchnet_4_LAYER_in_vivo.prototxt /home/caffe/models/susi/model_20SNR_20stain_3patch.caffemodel /home/caffe/models/susi/white.tif /home/caffe/models/susi/dark.tif
+CMD QT_GRAPHICSSYSTEM="native" QT_X11_NO_MITSHM=1 /home/xilens/build/xilens

--- a/src/display.h
+++ b/src/display.h
@@ -5,6 +5,7 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
+#include <QImage>
 #include <QObject>
 #include <QString>
 #include <boost/thread.hpp>
@@ -38,17 +39,17 @@ class Displayer : public QObject
     /**
      * Qt signal emitted when an RGB image is ready to be displayed in the UI.
      */
-    void ImageReadyToUpdateRGB(cv::Mat &);
+    void ImageReadyToUpdateRGB(QImage);
 
     /**
      * Qt signal emitted when a raw image is ready to be displayed in the UI.
      */
-    void ImageReadyToUpdateRaw(cv::Mat &);
+    void ImageReadyToUpdateRaw(QImage);
 
     /**
-     * Qt signal emitted when a new image is ready to compute the saturation percentage for the display.
+     * Qt signal emitted when the saturation values are ready to be displayed in the UI.
      */
-    void SaturationPercentageImageReady(cv::Mat &);
+    void SaturationPercentageReady(double undersaturation, double oversaturation);
 
   protected:
     /**

--- a/src/displayFunctional.h
+++ b/src/displayFunctional.h
@@ -7,6 +7,7 @@
 
 #include <xiApi.h>
 
+#include <QImage>
 #include <QObject>
 #include <QTimer>
 #include <boost/thread.hpp>
@@ -240,5 +241,23 @@ class DisplayerFunctional : public Displayer
  * The higher the value, the larger the intensity range of the resulting image.
  */
 void PrepareBGRImage(cv::Mat &bgr_image, int bgr_norm);
+
+/**
+ * Creates a QImage object from an OpenCv matrix and a given image format.
+ *
+ * @param image OpenCV matrix.
+ * @param format format of image, for example QImage::Format_BGR888.
+ * @return QImage.
+ * @throws std::invalid_argument if the input matrix is empty or of the wrong type.
+ */
+QImage GetQImageFromMatrix(cv::Mat &image, QImage::Format format);
+
+/**
+ * Computes the saturation percentages for underexposed and overexposed pixels from an image.
+ *
+ * @param image OpenCV matrix .
+ * @return Percentage of underexposed pixels (first value) and overexposed ones (second value).
+ */
+std::pair<double, double> GetSaturationPercentages(cv::Mat &image);
 
 #endif // DISPLAYFUNCTIONAL_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -10,6 +10,7 @@
 #include <QElapsedTimer>
 #include <QGraphicsScene>
 #include <QGuiApplication>
+#include <QImage>
 #include <QLineEdit>
 #include <QMainWindow>
 #include <QScreen>
@@ -145,9 +146,9 @@ class MainWindow : public QMainWindow
     /**
      * Updates the raw image displayed in the viewer tab.
      *
-     * @param image OpenCV patrix to display.
+     * @param image Qt image to display.
      */
-    void UpdateRawViewerImage(cv::Mat &image);
+    void UpdateRawViewerImage(QImage image);
 
     /**
      * Waits for the viewer thread to be running and for new values to be available in the queue. It emits a
@@ -159,14 +160,13 @@ class MainWindow : public QMainWindow
      * Takes an image, and scales it to the available width in the QtGraphicsView element before displaying it in the
      * provided scene.
      *
-     * @param image OpenCV matrix to be displayed.
-     * @param format format expected of the image, for example `QImage::Format_RGB888` for an 8bit RGB image.
+     * @param image Qt image to be displayed.
      * @param view the graphics view element where image will be displayed.
      * @param pixmapItem pixmap item where the image is to be placed.
      * @param scene the scene that will contain the pixmap.
      */
-    static void UpdateImage(cv::Mat &image, QImage::Format format, QGraphicsView *view,
-                            std::unique_ptr<QGraphicsPixmapItem> &pixmapItem, QGraphicsScene *scene);
+    static void UpdateImage(QImage image, QGraphicsView *view, std::unique_ptr<QGraphicsPixmapItem> &pixmapItem,
+                            QGraphicsScene *scene);
 
     /**
      * Identifies if the saturation tool button is checked or not.
@@ -227,32 +227,32 @@ class MainWindow : public QMainWindow
     /**
      * Qt signal that is emitted when reading an processing of the image to display in viewer tab is finished.
      *
-     * @param mat OpenCV matrix containing the image to display. This should be a one channel image.
+     * @param image Qt image containing the image to display. This should be a one channel image.
      */
-    void ViewerImageProcessingComplete(cv::Mat &mat);
+    void ViewerImageProcessingComplete(QImage image);
 
   public slots:
     /**
      * Qt slot that updates the RGB image displayed in the GUI.
      *
-     * @param image OpenCv matrix containing an 8bit (per channel) RGB image to be displayed.
+     * @param image Qt image containing an 8bit (per channel) RGB image to be displayed.
      */
-    void UpdateRGBImage(cv::Mat &image);
+    void UpdateRGBImage(QImage image);
 
     /**
      * Qt slot that updates the raw image displayed in the GUI.
      *
-     * @param image OpenCV matrix containing an 8bit single channel image to be displayed.
+     * @param image Qt image containing an 8bit single channel image to be displayed.
      */
-    void UpdateRawImage(cv::Mat &image);
+    void UpdateRawImage(QImage image);
 
     /**
      * Qt slot that updates the saturation percentage on the LCD displays.
      *
-     * @param image The input image of type CV_8UC1. It must be non-empty.
-     * @throws std::invalid_argument if the input matrix is empty or of the wrong type.
+     * @param percentageBelowThreshold Percentage of under-exposed pixels.
+     * @param percentageAboveThreshold Percentage of overexposed pixels.
      */
-    void UpdateSaturationPercentageLCDDisplays(cv::Mat &image) const;
+    void UpdateSaturationPercentageLCDDisplays(double percentageBelowThreshold, double percentageAboveThreshold) const;
 
   private slots:
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>susi control</string>
+   <string>XiLens</string>
   </property>
   <widget class="QWidget" name="centralWidget">
    <property name="sizePolicy">

--- a/tests/displayersTest.cpp
+++ b/tests/displayersTest.cpp
@@ -30,3 +30,24 @@ TEST(DisplayerFunctional, DisplayImage)
     delete[] static_cast<unsigned char *>(image->bp);
     delete image;
 }
+
+TEST(GetSaturationPercentagesTest, ValidInput)
+{
+    cv::Mat image = (cv::Mat_<uchar>(2, 5) << 5, 5, 5, 5, 5, 250, 250, 250, 250, 250);
+    auto [belowThreshold, aboveThreshold] = GetSaturationPercentages(image);
+    EXPECT_NEAR(belowThreshold, 50.0, 0.01);
+    EXPECT_NEAR(aboveThreshold, 50.0, 0.01);
+}
+
+TEST(GetSaturationPercentagesTest, EmptyMatrix)
+{
+    cv::Mat image;
+    EXPECT_THROW({ auto result = GetSaturationPercentages(image); }, std::invalid_argument);
+}
+
+TEST(GetSaturationPercentagesTest, IncorrectMatrixType)
+{
+    cv::Mat image = cv::Mat::zeros(3, 3, CV_32F);
+
+    EXPECT_THROW({ auto result = GetSaturationPercentages(image); }, std::invalid_argument);
+}

--- a/tests/mainWindowTest.cpp
+++ b/tests/mainWindowTest.cpp
@@ -21,22 +21,9 @@ class MockMainWindowTest : public ::testing::Test
     }
 };
 
-TEST_F(MockMainWindowTest, UpdateSaturationDisplaysTest_EmptyImage)
+TEST_F(MockMainWindowTest, UpdateSaturationDisplays)
 {
-    cv::Mat image; // Empty image
-    ASSERT_THROW(mockMainWindow->UpdateSaturationPercentageLCDDisplays(image), std::invalid_argument);
-}
-
-TEST_F(MockMainWindowTest, UpdateSaturationDisplaysTest_WrongImageType)
-{
-    cv::Mat image = cv::Mat::ones(10, 10, CV_8UC3) * 128; // RGB image
-    ASSERT_THROW(mockMainWindow->UpdateSaturationPercentageLCDDisplays(image), std::invalid_argument);
-}
-
-TEST_F(MockMainWindowTest, UpdateSaturationDisplaysTest_ValidImage)
-{
-    cv::Mat image = cv::Mat::ones(10, 10, CV_8UC1) * 128; // Valid grayscale image
-    ASSERT_NO_THROW(mockMainWindow->UpdateSaturationPercentageLCDDisplays(image));
+    ASSERT_NO_THROW(mockMainWindow->UpdateSaturationPercentageLCDDisplays(100, 0));
 }
 
 TEST_F(MockMainWindowTest, EnableUI)
@@ -69,23 +56,6 @@ TEST_F(MockMainWindowTest, WriteLogHeaderTest)
     {
         ASSERT_TRUE(false);
     }
-}
-
-TEST_F(MockMainWindowTest, GivenValidImage_WhenUpdateSaturationPercentageLCDDisplays_ThenCorrectValuesAreDisplayed)
-{
-    // Create a valid image
-    cv::Mat image = cv::Mat::zeros(10, 10, CV_8UC1);
-    image(cv::Rect(0, 0, 10, 10)).setTo(255); // Set part of the image to a high value
-    // Execute
-    EXPECT_NO_THROW(mockMainWindow->UpdateSaturationPercentageLCDDisplays(image));
-}
-
-TEST_F(MockMainWindowTest, GivenInvalidImage_WhenUpdateSaturationPercentageLCDDisplays_ThenExceptionIsThrown)
-{
-    // Create an invalid image
-    cv::Mat emptyImage;
-    // Expect an exception to be thrown
-    EXPECT_THROW(mockMainWindow->UpdateSaturationPercentageLCDDisplays(emptyImage), std::invalid_argument);
 }
 
 TEST_F(MockMainWindowTest, DisplayRecordedImageCounter)


### PR DESCRIPTION
## Description

Fixes signaling of images for compatibility with ubuntu 24.04. `QImage` is used as default for all connections instead of `cv::matrix`.

## Related Issue

#42 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
