### PR TITLE
Fix invalid json configuration path

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -24,7 +24,9 @@ bool isCameraSupported(const QString &type, const QString &family)
 QMap<QString, CameraData> loadCameraMapperFromJson(const QString &fileName)
 {
     QDir dir;
-    if (QCoreApplication::applicationDirPath() == QDir::cleanPath(QDir::fromNativeSeparators("/usr/bin")))
+    auto appDir = QCoreApplication::applicationDirPath();
+    if ((appDir == QDir::cleanPath(QDir::fromNativeSeparators("/usr/local/bin"))) ||
+        (appDir == QDir::cleanPath(QDir::fromNativeSeparators("/usr/bin"))))
     {
         dir.setPath(QDir::fromNativeSeparators("/etc/xilens"));
     }
@@ -34,6 +36,10 @@ QMap<QString, CameraData> loadCameraMapperFromJson(const QString &fileName)
     }
 
     QFile file(dir.filePath(fileName));
+    if (!file.exists())
+    {
+        LOG_XILENS(error) << "File does not exist: " << file.fileName().toStdString();
+    }
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
     {
         LOG_XILENS(error) << "Cannot open file";


### PR DESCRIPTION
## Description

Adds local bin path as a valid path for location of xilens when checking for JSON configuration file.

## Related Issue

#44 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
