### PR TITLE
Added check to existing file consistency before appending data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- New check for metadata to make sure metadata is consistent before appending data to an existing file.
 
 ### Changed
 
--
+- Refactors snapshot recording method to make it more modular
 
 ### Removed
 
--
+- Removes unused includes
 
 ### Fixed
 
--
+- Fixes deprecation warnings when building docker image
 
 ## [0.2.2]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ set(XILENS_LIB_HDR src/mainwindow.h
         src/xiAPIWrapper.h
         src/constants.h
         src/widgets.h
+        src/errors.h
 )
 set(XILENS_LIB_UI src/mainwindow.ui)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN xvfb-run -a --server-args="-screen 0 1024x768x24" make package -j
 RUN dpkg -i xilens*.deb
 
 # run tests
-ENV QT_QPA_PLATFORM offscreen
+ENV QT_QPA_PLATFORM=offscreen
 RUN xvfb-run -a --server-args="-screen 0 1024x768x24" ctest --output-on-failure
 
 # run application
-CMD QT_GRAPHICSSYSTEM="native" QT_X11_NO_MITSHM=1 /home/xilens/build/xilens
+CMD ["/bin/sh", "-c", "QT_GRAPHICSSYSTEM=native QT_X11_NO_MITSHM=1 /home/xilens/cmake-build/xilens"]

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
     if (themeFile.open(QFile::ReadOnly | QFile::Text))
     {
         QTextStream stream(&themeFile);
-        QString stylesheetContent = stream.readAll();
+        const QString stylesheetContent = stream.readAll();
         a.setStyleSheet(stylesheetContent);
     }
     themeFile.close();

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -169,13 +169,12 @@ void XiQFamily::UpdateCameraTemperature()
     }
 }
 
-void Camera::SetExposure(int exp)
+void Camera::SetExposure(const int exp) const
 {
-    int stat = XI_INVALID_HANDLE;
     if (INVALID_HANDLE_VALUE != *m_cameraHandle)
     {
         // Setting "exposure" parameter (10ms=10000us)
-        stat = this->m_apiWrapper->xiSetParamInt(*m_cameraHandle, XI_PRM_EXPOSURE, exp);
+        const int stat = this->m_apiWrapper->xiSetParamInt(*m_cameraHandle, XI_PRM_EXPOSURE, exp);
         HandleResult(stat, "xiSetParam (exposure set)");
         LOG_XILENS(info) << "set exposure to " << exp / 1000 << "ms\n" << std::flush;
     }
@@ -185,12 +184,12 @@ void Camera::SetExposure(int exp)
     }
 }
 
-void Camera::SetExposureMs(int exp)
+void Camera::SetExposureMs(const int exp) const
 {
     this->SetExposure(exp * 1000);
 }
 
-int Camera::GetExposure()
+int Camera::GetExposure() const
 {
     int stat = XI_OK;
     int exp = 40000;
@@ -209,17 +208,16 @@ int Camera::GetExposure()
     return exp;
 }
 
-int Camera::GetExposureMs()
+int Camera::GetExposureMs() const
 {
     return (this->GetExposure() + 5) / 1000;
 }
 
-void Camera::AutoExposure(bool on)
+void Camera::AutoExposure(const bool on) const
 {
-    int stat = XI_INVALID_HANDLE;
     if (INVALID_HANDLE_VALUE != *m_cameraHandle)
     {
-        stat = this->m_apiWrapper->xiSetParamInt(*m_cameraHandle, XI_PRM_AEAG, on);
+        const int stat = this->m_apiWrapper->xiSetParamInt(*m_cameraHandle, XI_PRM_AEAG, on);
         HandleResult(stat, "xiSetParam (autoexposure on/off)");
     }
     else

--- a/src/camera.h
+++ b/src/camera.h
@@ -6,8 +6,6 @@
 #ifndef XILENS_CAMERA_H
 #define XILENS_CAMERA_H
 
-#include <QMap>
-#include <QString>
 #include <boost/thread.hpp>
 #include <xiApi.h>
 
@@ -32,6 +30,8 @@ class CameraFamily
     boost::mutex m_mutexCameraTemperature;
 
   public:
+    virtual ~CameraFamily() = default;
+
     explicit CameraFamily(HANDLE *handle) : m_cameraHandle(handle)
     {
     }
@@ -218,6 +218,8 @@ class Camera
     HANDLE *m_cameraHandle;
 
   public:
+    virtual ~Camera() = default;
+
     /**
      * Constructor of camera class
      *
@@ -241,8 +243,6 @@ class Camera
     /**
      * initializes camera by setting parameters such as framerate, binning mode,
      * etc.
-     *
-     * @param cameraHandle camera handle for communication with the camera
      */
     virtual int InitializeCamera();
 
@@ -260,7 +260,7 @@ class Camera
      *
      * @param exp The exposure value to be set.
      */
-    void SetExposure(int exp);
+    void SetExposure(int exp) const;
 
     /**
      * \brief Sets the exposure time in milliseconds.
@@ -270,7 +270,7 @@ class Camera
      *
      * \param exp The exposure time in milliseconds.
      */
-    void SetExposureMs(int exp);
+    void SetExposureMs(int exp) const;
 
     /**
      * @brief Retrieves the exposure value.
@@ -281,7 +281,7 @@ class Camera
      *
      * @return The exposure value.
      */
-    int GetExposure();
+    int GetExposure() const;
 
     /**
      * @brief Retrieves the exposure time in milliseconds.
@@ -290,7 +290,7 @@ class Camera
      *
      * @return The exposure time in milliseconds.
      */
-    int GetExposureMs();
+    int GetExposureMs() const;
 
     /**
      * \brief A method to control auto exposure settings.
@@ -299,7 +299,7 @@ class Camera
      * camera. It is used to adjust the camera settings automatically based on the
      * lighting conditions.
      */
-    void AutoExposure(bool on);
+    void AutoExposure(bool on) const;
 };
 
 /**
@@ -320,8 +320,6 @@ class SpectralCamera : public Camera
     /**
      * Initializes the camera by setting parameters common to all cameras and also
      * specific values for spectral cameras.
-     *
-     * @param cameraHandle camera handle for management of all interactions with
      * it
      */
     int InitializeCamera() override;
@@ -346,8 +344,6 @@ class GrayCamera : public Camera
     /**
      * Initializes the camera by setting parameters common to all cameras and also
      * specific values for gray scale cameras.
-     *
-     * @param cameraHandle camera handle used to manage all interactions with it
      */
     int InitializeCamera() override;
 };
@@ -371,8 +367,6 @@ class RGBCamera : public Camera
     /**
      * Initializes the camera by setting parameters common to all cameras and also
      * specific values for RGB cameras.
-     *
-     * @param cameraHandle camera handle used to manage all interactions with it
      */
     int InitializeCamera() override;
 };

--- a/src/cameraInterface.cpp
+++ b/src/cameraInterface.cpp
@@ -5,7 +5,6 @@
 #include "cameraInterface.h"
 
 #include <boost/log/trivial.hpp>
-#include <iostream>
 #include <stdexcept>
 #include <utility>
 
@@ -13,7 +12,7 @@
 #include "logger.h"
 #include "util.h"
 
-void CameraInterface::Initialize(std::shared_ptr<XiAPIWrapper> apiWrapper)
+void CameraInterface::Initialize(const std::shared_ptr<XiAPIWrapper> &apiWrapper)
 {
     int stat = XI_OK;
     this->m_apiWrapper = apiWrapper;
@@ -23,7 +22,7 @@ void CameraInterface::Initialize(std::shared_ptr<XiAPIWrapper> apiWrapper)
     LOG_XILENS(info) << "number of ximea devices found: " << numberDevices;
 }
 
-void CameraInterface::SetCameraProperties(QString cameraModel)
+void CameraInterface::SetCameraProperties(const QString &cameraModel)
 {
     if (!getCameraMapper().contains(cameraModel))
     {
@@ -34,12 +33,12 @@ void CameraInterface::SetCameraProperties(QString cameraModel)
     this->m_cameraFamilyName = getCameraMapper().value(cameraModel).cameraFamily;
 }
 
-void CameraInterface::SetCameraIndex(int index)
+void CameraInterface::SetCameraIndex(const int index)
 {
     this->m_cameraIndex = index;
 }
 
-int CameraInterface::StartAcquisition(QString cameraIdentifier)
+void CameraInterface::StartAcquisition(QString cameraIdentifier)
 {
     if (!m_availableCameras.contains(cameraIdentifier))
     {
@@ -48,33 +47,28 @@ int CameraInterface::StartAcquisition(QString cameraIdentifier)
     }
     int stat_open = OpenDevice(m_availableCameras[cameraIdentifier]);
     HandleResult(stat_open, "OpenDevice");
-    auto openedCameraIdentifier = GetCameraIdentifier(m_cameraHandle);
-    if (openedCameraIdentifier != cameraIdentifier)
+    if (auto openedCameraIdentifier = GetCameraIdentifier(m_cameraHandle); openedCameraIdentifier != cameraIdentifier)
     {
         LOG_XILENS(error) << "Opened camera not the same as selected camera: " << cameraIdentifier.toStdString()
                           << "!=" << cameraIdentifier.toStdString();
         throw std::runtime_error("Opened camera is not the same as the selected one.");
     }
 
-    char cameraSN[100] = {0};
+    char cameraSN[100] = {};
     this->m_apiWrapper->xiGetParamString(this->m_cameraHandle, XI_PRM_DEVICE_SN, cameraSN, sizeof(cameraSN));
     this->m_cameraSN = QString::fromUtf8(cameraSN);
 
-    if (INVALID_HANDLE_VALUE != this->m_cameraHandle)
-    {
-        LOG_XILENS(info) << "Starting acquisition";
-        int stat = this->m_apiWrapper->xiStartAcquisition(this->m_cameraHandle);
-        HandleResult(stat, "xiStartAcquisition");
-        LOG_XILENS(info) << "successfully initialized camera\n";
-        return stat;
-    }
-    else
+    if (this->m_cameraHandle == INVALID_HANDLE_VALUE)
     {
         throw std::runtime_error("didn't start acquisition, camera invalid handle");
     }
+    LOG_XILENS(info) << "Starting acquisition";
+    int stat = this->m_apiWrapper->xiStartAcquisition(this->m_cameraHandle);
+    HandleResult(stat, "xiStartAcquisition");
+    LOG_XILENS(info) << "successfully initialized camera\n";
 }
 
-int CameraInterface::StopAcquisition()
+int CameraInterface::StopAcquisition() const
 {
     int stat = XI_INVALID_HANDLE;
     if (INVALID_HANDLE_VALUE != this->m_cameraHandle)
@@ -87,11 +81,11 @@ int CameraInterface::StopAcquisition()
     return stat;
 }
 
-int CameraInterface::OpenDevice(DWORD cameraDeviceID)
+int CameraInterface::OpenDevice(const DWORD cameraDeviceID)
 {
     int stat = XI_OK;
     stat = this->m_apiWrapper->xiOpenDevice(cameraDeviceID, &m_cameraHandle);
-    HandleResult(stat, "xiOepnDevice");
+    HandleResult(stat, "xiOpenDevice");
 
     this->SetCamera(m_cameraType, m_cameraFamilyName);
 
@@ -106,18 +100,17 @@ int CameraInterface::OpenDevice(DWORD cameraDeviceID)
 
 void CameraInterface::CloseDevice()
 {
-    int stat = XI_INVALID_HANDLE;
     if (INVALID_HANDLE_VALUE != this->m_cameraHandle)
     {
         LOG_XILENS(info) << "Closing device";
-        stat = this->m_apiWrapper->xiCloseDevice(this->m_cameraHandle);
+        const int stat = this->m_apiWrapper->xiCloseDevice(this->m_cameraHandle);
         this->m_cameraHandle = INVALID_HANDLE_VALUE;
         HandleResult(stat, "xiCloseDevice");
         LOG_XILENS(info) << "Done!";
     }
 }
 
-HANDLE CameraInterface::GetHandle()
+HANDLE CameraInterface::GetHandle() const
 {
     return this->m_cameraHandle;
 }
@@ -132,9 +125,8 @@ QStringList CameraInterface::GetAvailableCameraIdentifiers()
 
     for (DWORD i = 0; i < dwCamCount; i++)
     {
-        HANDLE cameraHandle = INVALID_HANDLE_VALUE;
-        int stat = this->m_apiWrapper->xiOpenDevice(i, &cameraHandle);
-        if (stat != XI_OK)
+        auto cameraHandle = INVALID_HANDLE_VALUE;
+        if (const int stat = this->m_apiWrapper->xiOpenDevice(i, &cameraHandle); stat != XI_OK)
         {
             LOG_XILENS(error) << "cannot open device with ID: " << i << " perhaps already open?";
         }
@@ -150,9 +142,9 @@ QStringList CameraInterface::GetAvailableCameraIdentifiers()
     return cameraIdentifiers;
 }
 
-QString CameraInterface::GetCameraIdentifier(HANDLE cameraHandle)
+QString CameraInterface::GetCameraIdentifier(const HANDLE cameraHandle) const
 {
-    char cameraModel[256] = {0};
+    char cameraModel[256] = {};
     char sensorSN[100] = "";
     this->m_apiWrapper->xiGetParamString(cameraHandle, XI_PRM_DEVICE_NAME, cameraModel, sizeof(cameraModel));
     this->m_apiWrapper->xiGetParamString(cameraHandle, XI_PRM_DEVICE_SENS_SN, sensorSN, sizeof(sensorSN));
@@ -169,7 +161,7 @@ CameraInterface::~CameraInterface()
     }
 }
 
-void CameraInterface::SetCamera(QString cameraType, QString cameraFamily)
+void CameraInterface::SetCamera(const QString &cameraType, const QString &cameraFamily)
 {
     // instantiate camera type
     if (cameraType == CAMERA_TYPE_SPECTRAL)

--- a/src/cameraInterface.h
+++ b/src/cameraInterface.h
@@ -7,13 +7,9 @@
 
 #include <xiApi.h>
 
-#include <QObject>
-#include <QString>
 #include <QtCore>
 #include <boost/asio/io_service.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <opencv2/core/core.hpp>
-#include <string>
 
 #include "camera.h"
 #include "constants.h"

--- a/src/cameraInterface.h
+++ b/src/cameraInterface.h
@@ -45,7 +45,7 @@ class CameraInterface : public QObject
     /**
      * Check if XIMEA cameras are connected and counts them
      */
-    void Initialize(std::shared_ptr<XiAPIWrapper> apiWrapper);
+    void Initialize(const std::shared_ptr<XiAPIWrapper> &apiWrapper);
 
     /**
      * Wrapper to xiAPI, useful for mocking the aPI during testing
@@ -57,7 +57,7 @@ class CameraInterface : public QObject
      */
     ~CameraInterface();
 
-    void SetCamera(QString cameraType, QString cameraFamily);
+    void SetCamera(const QString &cameraType, const QString &cameraFamily);
 
     /**
      * @brief Initializes a device with the specified camera ID.
@@ -77,7 +77,7 @@ class CameraInterface : public QObject
      *
      * @param cameraIdentifier The deviceID used by XiAPI to open the device.
      */
-    int StartAcquisition(QString cameraIdentifier);
+    void StartAcquisition(QString cameraIdentifier);
 
     /**
      * @brief Stops the acquisition process.
@@ -87,7 +87,7 @@ class CameraInterface : public QObject
      *
      * @see StartAcquisition
      */
-    int StopAcquisition();
+    int StopAcquisition() const;
 
     /**
      * @brief Closes the device.
@@ -111,7 +111,7 @@ class CameraInterface : public QObject
      *
      * \param cameraModel A QString specifying the camera type.
      */
-    void SetCameraProperties(QString cameraModel);
+    void SetCameraProperties(const QString &cameraModel);
 
     /**
      * @brief Sets the camera index.
@@ -165,7 +165,7 @@ class CameraInterface : public QObject
      *
      * @return The handle associated with the current object.
      */
-    HANDLE GetHandle();
+    HANDLE GetHandle() const;
 
     /**
      * @brief Map of available cameras.
@@ -197,7 +197,7 @@ class CameraInterface : public QObject
      * @param cameraHandle Handle of the camera, it should be a valid handle initialized by `xiOpenDevice`.
      * @return camera identifier in the format `camera_model@sensorSN`.
      */
-    QString GetCameraIdentifier(HANDLE cameraHandle);
+    QString GetCameraIdentifier(HANDLE cameraHandle) const;
 
     /**
      * @brief The variable m_cameraIdentifier represents the model of the camera being

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -13,18 +13,18 @@
 
 bool isCameraSupported(const QString &type, const QString &family)
 {
-    return (std::find(SUPPORTED_CAMERA_TYPES.begin(), SUPPORTED_CAMERA_TYPES.end(), type) !=
-            SUPPORTED_CAMERA_TYPES.end()) &&
-           (std::find(SUPPORTED_CAMERA_FAMILIES.begin(), SUPPORTED_CAMERA_FAMILIES.end(), family) !=
-            SUPPORTED_CAMERA_FAMILIES.end());
+    return std::find(SUPPORTED_CAMERA_TYPES.begin(), SUPPORTED_CAMERA_TYPES.end(), type) !=
+               SUPPORTED_CAMERA_TYPES.end() &&
+           std::find(SUPPORTED_CAMERA_FAMILIES.begin(), SUPPORTED_CAMERA_FAMILIES.end(), family) !=
+               SUPPORTED_CAMERA_FAMILIES.end();
 }
 
 QMap<QString, CameraData> loadCameraMapperFromJson(const QString &fileName)
 {
     QDir dir;
-    auto appDir = QCoreApplication::applicationDirPath();
-    if ((appDir == QDir::cleanPath(QDir::fromNativeSeparators("/usr/local/bin"))) ||
-        (appDir == QDir::cleanPath(QDir::fromNativeSeparators("/usr/bin"))))
+    const auto appDir = QCoreApplication::applicationDirPath();
+    if (appDir == QDir::cleanPath(QDir::fromNativeSeparators("/usr/local/bin")) ||
+        appDir == QDir::cleanPath(QDir::fromNativeSeparators("/usr/bin")))
     {
         dir.setPath(QDir::fromNativeSeparators("/etc/xilens"));
     }
@@ -44,7 +44,7 @@ QMap<QString, CameraData> loadCameraMapperFromJson(const QString &fileName)
         throw std::runtime_error("Cannot open file");
     }
     LOG_XILENS(info) << "loading camera properties from: " << QFileInfo(file).absoluteFilePath().toStdString();
-    QJsonDocument document = QJsonDocument::fromJson(file.readAll());
+    const QJsonDocument document = QJsonDocument::fromJson(file.readAll());
     file.close();
 
     if (document.isNull())

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -7,8 +7,6 @@
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
-#include <QJsonObject>
-#include <QStringList>
 
 #include "constants.h"
 #include "logger.h"

--- a/src/constants.h
+++ b/src/constants.h
@@ -9,7 +9,6 @@
 #include <QJsonObject>
 #include <QMap>
 #include <QString>
-#include <QVariant>
 #include <opencv2/opencv.hpp>
 
 /**

--- a/src/constants.h
+++ b/src/constants.h
@@ -245,6 +245,17 @@ constexpr const char *COLOR_FILTER_ARRAY_FORMAT_KEY = "color_filter_array";
 constexpr const char *TIME_STAMP_KEY = "time_stamp";
 
 /**
+ * @brief List of metadata keys expected to be present in an image file.
+ *
+ * This vector contains the predefined keys required for metadata validation
+ * during file operations. Each key corresponds to a specific piece of image
+ * metadata, such as exposure time, frame number, color filter array format,
+ * timestamp, and sensor board temperature.
+ */
+const std::vector<QString> EXPECTED_METADATA_KEYS = {EXPOSURE_KEY, FRAME_NUMBER_KEY, COLOR_FILTER_ARRAY_FORMAT_KEY,
+                                                     TIME_STAMP_KEY, SENSOR_BOARD_TEMP};
+
+/**
  * @brief Maximum number of frames used to compute the frames per second at which recordings happen.
  */
 const int MAX_FRAMES_TO_COMPUTE_FPS = 10;

--- a/src/constants.h
+++ b/src/constants.h
@@ -14,25 +14,25 @@
 /**
  * @brief Maximum width of image to display.
  */
-const int MAX_WIDTH_DISPLAY_WINDOW = 1024;
+constexpr int MAX_WIDTH_DISPLAY_WINDOW = 1024;
 /**
  * @brief Maximum height of image to display.
  */
-const int MAX_HEIGHT_DISPLAY_WINDOW = 544;
+constexpr int MAX_HEIGHT_DISPLAY_WINDOW = 544;
 
 /**
  * @brief Color used to represent saturation pixels.
  *
  * This color is represented as a BGR vector with values (180, 105, 255).
  */
-const cv::Vec3b SATURATION_COLOR = cv::Vec3b(180, 105, 255);
+const auto SATURATION_COLOR = cv::Vec3b(180, 105, 255);
 
 /**
  * @brief Color used to represent dark pixels.
  *
  * This color is represented as a BGR vector with values (0, 0, 255).
  */
-const cv::Vec3b DARK_COLOR = cv::Vec3b(0, 0, 255);
+const auto DARK_COLOR = cv::Vec3b(0, 0, 255);
 
 /**
  * @brief File name where logs are stored.
@@ -58,7 +58,7 @@ const QString SENSOR_BOARD_TEMP = "temperature_sensor_board";
 /**
  * @brief Variable used to identify how ofter temperature is queried from the camera.
  */
-const int TEMP_LOG_INTERVAL = 5;
+constexpr int TEMP_LOG_INTERVAL = 5;
 
 /**
  * @brief Original style of input component.
@@ -72,20 +72,20 @@ const QString FIELD_EDITED_STYLE = "QLineEdit {background-color: rgba(117, 52, 1
 /**
  * @brief Maximum framerate at which images are polled from camera.
  */
-const int FRAMERATE_MAX = 80;
+constexpr int FRAMERATE_MAX = 80;
 
 /**
  * @brief maximum value in range [0, 255] above which pixels are considered over-saturated.
  *
  * The maximum value is `225` in the range `[0,255]`, which corresponds to `900` in the range `[0, 1024]`.
  */
-const int OVEREXPOSURE_PIXEL_BOUNDARY_VALUE = 225;
+constexpr int OVEREXPOSURE_PIXEL_BOUNDARY_VALUE = 225;
 /**
  * @brief minimum value in range [0, 255] below which pixels are considered under-saturated.
  *
  * The minimum value is `10` in the range `[0,255]`, which corresponds to `40` in the range `[0, 1024]`.
  */
-const int UNDEREXPOSURE_PIXEL_BOUNDARY_VALUE = 10;
+constexpr int UNDEREXPOSURE_PIXEL_BOUNDARY_VALUE = 10;
 
 /**
  * @brief Name of spectral camera type.
@@ -131,19 +131,19 @@ const QString CAMERA_FAMILY_XIX = "xiX";
 /**
  * @brief Vector of supported camera types.
  */
-const std::vector<QString> SUPPORTED_CAMERA_TYPES = {CAMERA_TYPE_SPECTRAL, CAMERA_TYPE_GRAY, CAMERA_TYPE_RGB};
+const std::vector SUPPORTED_CAMERA_TYPES = {CAMERA_TYPE_SPECTRAL, CAMERA_TYPE_GRAY, CAMERA_TYPE_RGB};
 
 /**
  * @brief Vector of supported camera families.
  */
-const std::vector<QString> SUPPORTED_CAMERA_FAMILIES = {CAMERA_FAMILY_XISPEC, CAMERA_FAMILY_XIC,   CAMERA_FAMILY_XIQ,
-                                                        CAMERA_FAMILY_XIB,    CAMERA_FAMILY_XIB64, CAMERA_FAMILY_XIRAY,
-                                                        CAMERA_FAMILY_XIX};
+const std::vector SUPPORTED_CAMERA_FAMILIES = {CAMERA_FAMILY_XISPEC, CAMERA_FAMILY_XIC,   CAMERA_FAMILY_XIQ,
+                                               CAMERA_FAMILY_XIB,    CAMERA_FAMILY_XIB64, CAMERA_FAMILY_XIRAY,
+                                               CAMERA_FAMILY_XIX};
 
 /**
  * @brief Number of images to record for reference images for `white` and `dark`.
  */
-const int NR_REFERENCE_IMAGES_TO_RECORD = 100;
+constexpr int NR_REFERENCE_IMAGES_TO_RECORD = 100;
 
 /**
  * @brief Structure to hold metadata from camera such as type, family, etc.
@@ -226,22 +226,22 @@ QMap<QString, CameraData> &getCameraMapper();
 /**
  * @brief Name of key to be used to store exposure time in the metadata of the arrays.
  */
-constexpr const char *EXPOSURE_KEY = "exposure_us";
+constexpr auto EXPOSURE_KEY = "exposure_us";
 
 /**
  * @brief Name of key to be used to store frame number in the metadata of the arrays.
  */
-constexpr const char *FRAME_NUMBER_KEY = "acq_nframe";
+constexpr auto FRAME_NUMBER_KEY = "acq_nframe";
 
 /**
  * @brief Name of key to be used to store filter array format in the metadata of the arrays.
  */
-constexpr const char *COLOR_FILTER_ARRAY_FORMAT_KEY = "color_filter_array";
+constexpr auto COLOR_FILTER_ARRAY_FORMAT_KEY = "color_filter_array";
 
 /**
  * @brief Name of key to be used to store time stamp in the metadata of the arrays.
  */
-constexpr const char *TIME_STAMP_KEY = "time_stamp";
+constexpr auto TIME_STAMP_KEY = "time_stamp";
 
 /**
  * @brief List of metadata keys expected to be present in an image file.
@@ -257,11 +257,11 @@ const std::vector<QString> EXPECTED_METADATA_KEYS = {EXPOSURE_KEY, FRAME_NUMBER_
 /**
  * @brief Maximum number of frames used to compute the frames per second at which recordings happen.
  */
-const int MAX_FRAMES_TO_COMPUTE_FPS = 10;
+constexpr int MAX_FRAMES_TO_COMPUTE_FPS = 10;
 
 /**
  * @brief Rate in milliseconds at which the frames per second display in the UI is updated.
  */
-const int UPDATE_RATE_MS_FPS_TIMER = 2000;
+constexpr int UPDATE_RATE_MS_FPS_TIMER = 2000;
 
 #endif

--- a/src/display.h
+++ b/src/display.h
@@ -9,7 +9,6 @@
 #include <QObject>
 #include <QString>
 #include <boost/thread.hpp>
-#include <opencv2/core.hpp>
 #include <xiApi.h>
 
 /**

--- a/src/displayFunctional.cpp
+++ b/src/displayFunctional.cpp
@@ -5,7 +5,6 @@
 #include <boost/thread.hpp>
 #include <iostream>
 #include <opencv2/core/core.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
 #include <string>
 #include <utility>
 

--- a/src/displayFunctional.cpp
+++ b/src/displayFunctional.cpp
@@ -16,9 +16,9 @@
 
 typedef cv::Point3_<uint8_t> Pixel;
 
-DisplayerFunctional::DisplayerFunctional(MainWindow *mainWindow) : Displayer(), m_mainWindow(mainWindow)
+DisplayerFunctional::DisplayerFunctional(MainWindow *mainWindow) : m_mainWindow(mainWindow)
 {
-    auto result = QObject::connect(&m_displayTimer, &QTimer::timeout, this, &DisplayerFunctional::OnDisplayTimeout);
+    const auto result = connect(&m_displayTimer, &QTimer::timeout, this, &DisplayerFunctional::OnDisplayTimeout);
     if (!result)
     {
         LOG_XILENS(error) << "Error while connecting displayer to timer";
@@ -35,7 +35,7 @@ DisplayerFunctional::~DisplayerFunctional()
         m_displayTimer.stop();
     }
     {
-        boost::lock_guard<boost::mutex> guard(m_mutexImageDisplay);
+        boost::lock_guard guard(m_mutexImageDisplay);
         m_stop = true;
     }
     m_displayCondition.notify_all();
@@ -44,29 +44,32 @@ DisplayerFunctional::~DisplayerFunctional()
     {
         m_displayThread.join();
     }
-    QObject::disconnect();
+    if (disconnect())
+    {
+        LOG_XILENS(error) << "Error while disconnecting displayer from timer";
+    }
     m_clahe.release();
 }
 
-void PrepareBGRImage(cv::Mat &bgr_image, int bgr_norm)
+void PrepareBGRImage(cv::Mat &bgr_image, const int bgr_norm)
 {
     double min, max;
     static double last_norm = 1.;
-    cv::minMaxLoc(bgr_image, &min, &max);
+    minMaxLoc(bgr_image, &min, &max);
 
-    last_norm = 0.9 * last_norm + (double)bgr_norm * 0.01 * max;
+    last_norm = 0.9 * last_norm + static_cast<double>(bgr_norm) * 0.01 * max;
 
     bgr_image *= 255. / last_norm;
     bgr_image.convertTo(bgr_image, CV_8UC3);
 }
 
-void DisplayerFunctional::NormalizeBGRImage(cv::Mat &bgr_image)
+void DisplayerFunctional::NormalizeBGRImage(cv::Mat &bgr_image) const
 {
     cv::Mat lab_image;
     cvtColor(bgr_image, lab_image, cv::COLOR_BGR2Lab);
     // extract L channel
     std::vector<cv::Mat> lab_planes(3);
-    cv::split(lab_image, lab_planes);
+    split(lab_image, lab_planes);
 
     // apply m_clahe to the L channel and save it in lab_planes
     cv::Mat dst;
@@ -78,14 +81,14 @@ void DisplayerFunctional::NormalizeBGRImage(cv::Mat &bgr_image)
     cv::merge(lab_planes, lab_image);
 
     // convert back to rgb
-    cv::cvtColor(lab_image, bgr_image, cv::COLOR_Lab2BGR);
+    cvtColor(lab_image, bgr_image, cv::COLOR_Lab2BGR);
 }
 
-void DisplayerFunctional::PrepareRawImage(cv::Mat &raw_image, bool equalize_hist)
+void DisplayerFunctional::PrepareRawImage(cv::Mat &raw_image, const bool equalize_hist) const
 {
     cv::Mat mask = raw_image.clone();
     cvtColor(mask, mask, cv::COLOR_GRAY2RGB);
-    cv::LUT(mask, m_lut, mask);
+    LUT(mask, m_lut, mask);
     if (equalize_hist)
     {
         this->m_clahe->apply(raw_image, raw_image);
@@ -112,21 +115,21 @@ void DisplayerFunctional::PrepareRawImage(cv::Mat &raw_image, bool equalize_hist
     }
 }
 
-void DisplayerFunctional::GetBand(cv::Mat &image, cv::Mat &band_image, unsigned int band_nr)
+void DisplayerFunctional::GetBand(cv::Mat &image, cv::Mat &band_image, const unsigned int band_nr) const
 {
     if (band_nr < 1 || band_nr > (this->m_mosaicShape[0] * this->m_mosaicShape[1]))
     {
         throw std::out_of_range("Band number is out of the expected range.");
     }
     // compute location of first value
-    int init_col = static_cast<int>(band_nr - 1) % this->m_mosaicShape[0];
-    int init_row = static_cast<int>(band_nr - 1) / this->m_mosaicShape[1];
+    const int initCol = static_cast<int>(band_nr - 1) % this->m_mosaicShape[0];
+    const int initRow = static_cast<int>(band_nr - 1) / this->m_mosaicShape[1];
     // select data from the specific band
     int row = 0;
-    for (int i = init_row; i < image.rows; i += this->m_mosaicShape[0])
+    for (int i = initRow; i < image.rows; i += this->m_mosaicShape[0])
     {
         int col = 0;
-        for (int j = init_col; j < image.cols; j += this->m_mosaicShape[1])
+        for (int j = initCol; j < image.cols; j += this->m_mosaicShape[1])
         {
             band_image.at<ushort>(row, col) = image.at<ushort>(i, j);
             col++;
@@ -142,9 +145,9 @@ void DisplayerFunctional::DownsampleImageIfNecessary(cv::Mat &image)
     // Check if the image exceeds the maximum dimensions
     if (image.cols > MAX_WIDTH_DISPLAY_WINDOW || image.rows > MAX_HEIGHT_DISPLAY_WINDOW)
     {
-        double scale =
-            std::min((double)MAX_WIDTH_DISPLAY_WINDOW / image.cols, (double)MAX_HEIGHT_DISPLAY_WINDOW / image.rows);
-        cv::resize(image, image, cv::Size(), scale, scale, cv::INTER_AREA);
+        const double scale = std::min(static_cast<double>(MAX_WIDTH_DISPLAY_WINDOW) / image.cols,
+                                      static_cast<double>(MAX_HEIGHT_DISPLAY_WINDOW) / image.rows);
+        resize(image, image, cv::Size(), scale, scale, cv::INTER_AREA);
     }
 }
 
@@ -173,7 +176,7 @@ void DisplayerFunctional::OnDisplayTimeout()
     {
         XI_IMG image;
         {
-            boost::unique_lock<boost::mutex> lock(m_mutexImageDisplay);
+            boost::unique_lock lock(m_mutexImageDisplay);
             boost::this_thread::interruption_point();
             m_displayCondition.wait(lock, [this] { return m_hasPendingImage; });
 
@@ -196,7 +199,7 @@ void DisplayerFunctional::ProcessImage(XI_IMG &image)
     cv::Mat currentImage;
     int filterArrayType;
     {
-        boost::lock_guard<boost::mutex> guard(m_mutexImageDisplay);
+        boost::lock_guard guard(m_mutexImageDisplay);
         currentImage =
             cv::Mat(static_cast<int>(image.height), static_cast<int>(image.width), CV_16UC1, image.bp).clone();
         filterArrayType = image.color_filter_array;
@@ -228,7 +231,7 @@ void DisplayerFunctional::ProcessImage(XI_IMG &image)
         bgrImage = currentImage.clone();
         if (filterArrayType == XI_CFA_BAYER_GBRG)
         {
-            cv::cvtColor(bgrImage, bgrImage, cv::COLOR_BayerGB2BGR);
+            cvtColor(bgrImage, bgrImage, cv::COLOR_BayerGB2BGR);
         }
         else
         {
@@ -264,7 +267,7 @@ void DisplayerFunctional::ProcessImage(XI_IMG &image)
     emit SaturationPercentageReady(saturationValues.first, saturationValues.second);
 }
 
-void DisplayerFunctional::GetBGRImage(cv::Mat &image, cv::Mat &bgr_image)
+void DisplayerFunctional::GetBGRImage(cv::Mat &image, cv::Mat &bgr_image) const
 {
     if (!getCameraMapper().contains(m_cameraModel))
     {
@@ -278,7 +281,7 @@ void DisplayerFunctional::GetBGRImage(cv::Mat &image, cv::Mat &bgr_image)
         throw std::runtime_error("Empty RGB channel indices");
     }
     std::vector<cv::Mat> channels;
-    for (int i : bgrChannels)
+    for (const int i : bgrChannels)
     {
         cv::Mat band_image = InitializeBandImage(image);
         this->GetBand(image, band_image, i);
@@ -295,15 +298,15 @@ void DisplayerFunctional::GetBGRImage(cv::Mat &image, cv::Mat &bgr_image)
     }
 }
 
-cv::Mat DisplayerFunctional::InitializeBandImage(cv::Mat &image)
+cv::Mat DisplayerFunctional::InitializeBandImage(const cv::Mat &image) const
 {
-    int band_rows = (image.rows + m_mosaicShape[0] - 1) / m_mosaicShape[0]; // Using ceiling division
-    int band_cols = (image.cols + m_mosaicShape[1] - 1) / m_mosaicShape[1]; // Using ceiling division
-    cv::Mat band_image = cv::Mat::zeros(band_rows, band_cols, CV_16UC1);
-    return band_image;
+    const int bandRows = (image.rows + m_mosaicShape[0] - 1) / m_mosaicShape[0]; // Using ceiling division
+    const int bandCols = (image.cols + m_mosaicShape[1] - 1) / m_mosaicShape[1]; // Using ceiling division
+    cv::Mat bandImage = cv::Mat::zeros(bandRows, bandCols, CV_16UC1);
+    return bandImage;
 }
 
-void DisplayerFunctional::SetCameraProperties(QString cameraModel)
+void DisplayerFunctional::SetCameraProperties(const QString cameraModel)
 {
     if (!getCameraMapper().contains(cameraModel))
     {
@@ -315,13 +318,13 @@ void DisplayerFunctional::SetCameraProperties(QString cameraModel)
     this->m_mosaicShape = getCameraMapper().value(cameraModel).mosaicShape;
 }
 
-QImage GetQImageFromMatrix(cv::Mat &image, QImage::Format format)
+QImage GetQImageFromMatrix(const cv::Mat &image, const QImage::Format format)
 {
-    QImage qtImage((uchar *)image.data, image.cols, image.rows, static_cast<long>(image.step), format);
+    QImage qtImage(image.data, image.cols, image.rows, static_cast<long>(image.step), format);
     return qtImage;
 }
 
-std::pair<double, double> GetSaturationPercentages(cv::Mat &image)
+std::pair<double, double> GetSaturationPercentages(const cv::Mat &image)
 {
     if (image.empty() || image.type() != CV_8UC1)
     {
@@ -330,11 +333,11 @@ std::pair<double, double> GetSaturationPercentages(cv::Mat &image)
                                     cv::typeToString(image.type()));
     }
 
-    int aboveThresholdCount = cv::countNonZero(image > OVEREXPOSURE_PIXEL_BOUNDARY_VALUE);
-    auto totalPixels = static_cast<double>(image.total()); // Total number of pixels in the matrix
-    double percentageAboveThreshold = (static_cast<double>(aboveThresholdCount) / totalPixels) * 100.0;
+    const int aboveThresholdCount = countNonZero(image > OVEREXPOSURE_PIXEL_BOUNDARY_VALUE);
+    const auto totalPixels = static_cast<double>(image.total()); // Total number of pixels in the matrix
+    double percentageAboveThreshold = static_cast<double>(aboveThresholdCount) / totalPixels * 100.0;
 
-    int belowThresholdCount = cv::countNonZero(image < UNDEREXPOSURE_PIXEL_BOUNDARY_VALUE);
-    double percentageBelowThreshold = (static_cast<double>(belowThresholdCount) / totalPixels) * 100.0;
+    const int belowThresholdCount = countNonZero(image < UNDEREXPOSURE_PIXEL_BOUNDARY_VALUE);
+    double percentageBelowThreshold = static_cast<double>(belowThresholdCount) / totalPixels * 100.0;
     return std::make_pair(percentageBelowThreshold, percentageAboveThreshold);
 }

--- a/src/displayFunctional.h
+++ b/src/displayFunctional.h
@@ -40,12 +40,13 @@ class DisplayerFunctional : public Displayer
     /**
      * Constructor of functional displayer
      *
-     * @param mainWindow reference to main window application
      */
-    explicit DisplayerFunctional() : Displayer(){};
+    explicit DisplayerFunctional()
+    {
+    }
 
     /**
-     * Destructor of the DisplayerFunctional class. It destroy the windows created
+     * Destructor of the DisplayerFunctional class. It destroys the windows created
      * by the displayer.
      */
     ~DisplayerFunctional() override;
@@ -166,11 +167,12 @@ class DisplayerFunctional : public Displayer
 
     /**
      * @brief prepares raw image from XIMEA camera to be displayed, it does
-     * histogram normalization in case it is specified
+     * histogram normalization in case it is specified.
      *
-     * @param raw_image, the image to be processed
+     * @param raw_image the image to be processed.
+     * @param equalize_hist if image should be normalized.
      */
-    void PrepareRawImage(cv::Mat &raw_image, bool equalize_hist);
+    void PrepareRawImage(cv::Mat &raw_image, bool equalize_hist) const;
 
     /**
      * @brief Normalizes a BGR image using the LAB color space.
@@ -184,7 +186,7 @@ class DisplayerFunctional : public Displayer
      * @param bgr_image The BGR image to be normalized. Note that the input image
      * will be modified.
      */
-    void NormalizeBGRImage(cv::Mat &bgr_image);
+    void NormalizeBGRImage(cv::Mat &bgr_image) const;
 
     /**
      * @brief Extracts a specific band (channel) from an image
@@ -196,7 +198,7 @@ class DisplayerFunctional : public Displayer
      * @param band_image The output band image
      * @param band_nr The number of the band to extract
      */
-    void GetBand(cv::Mat &image, cv::Mat &band_image, unsigned int band_nr);
+    void GetBand(cv::Mat &image, cv::Mat &band_image, unsigned int band_nr) const;
 
     /**
      * @brief Get the BGR image from the input image by splitting it into separate
@@ -209,7 +211,7 @@ class DisplayerFunctional : public Displayer
      * @param image The input image from which channels will be extracted.
      * @param bgr_image The output BGR image.
      */
-    void GetBGRImage(cv::Mat &image, cv::Mat &rgb_image);
+    void GetBGRImage(cv::Mat &image, cv::Mat &bgr_image) const;
 
     /**
      * Initializes a channel image based on the raw image.
@@ -217,7 +219,7 @@ class DisplayerFunctional : public Displayer
      * @param image The raw image
      * @return Image filled with 0's with a size capable of holding a band image after demosaic operation is applied
      */
-    cv::Mat InitializeBandImage(cv::Mat &image);
+    cv::Mat InitializeBandImage(const cv::Mat &image) const;
 };
 
 /**
@@ -246,7 +248,7 @@ void PrepareBGRImage(cv::Mat &bgr_image, int bgr_norm);
  * @return QImage.
  * @throws std::invalid_argument if the input matrix is empty or of the wrong type.
  */
-QImage GetQImageFromMatrix(cv::Mat &image, QImage::Format format);
+QImage GetQImageFromMatrix(const cv::Mat &image, QImage::Format format);
 
 /**
  * Computes the saturation percentages for underexposed and overexposed pixels from an image.
@@ -254,6 +256,6 @@ QImage GetQImageFromMatrix(cv::Mat &image, QImage::Format format);
  * @param image OpenCV matrix .
  * @return Percentage of underexposed pixels (first value) and overexposed ones (second value).
  */
-std::pair<double, double> GetSaturationPercentages(cv::Mat &image);
+std::pair<double, double> GetSaturationPercentages(const cv::Mat &image);
 
 #endif // DISPLAYFUNCTIONAL_H

--- a/src/displayFunctional.h
+++ b/src/displayFunctional.h
@@ -7,13 +7,9 @@
 
 #include <xiApi.h>
 
-#include <QImage>
-#include <QObject>
-#include <QTimer>
 #include <boost/thread.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc.hpp>
-#include <string>
 
 #include "constants.h"
 #include "display.h"

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,0 +1,99 @@
+/*******************************************************
+ * Author: Intelligent Medical Systems
+ * License: see LICENSE.md file
+ *******************************************************/
+
+#ifndef ERRORS_H
+#define ERRORS_H
+
+#include <string>
+
+/**
+ * @brief Represents an error class for handling exceptions specific to the XiLens application.
+ *
+ * This class is used to encapsulate and manage error details, including error codes,
+ * messages, and other related properties associated with errors in the XiLens application.
+ * It provides an interface for retrieving error information and debugging issues
+ * encountered during application runtime.
+ */
+class XiLensError final : public std::exception
+{
+  public:
+    enum class Code
+    {
+        None,
+        FileInconsistentMetadata
+    };
+
+    /**
+     * Constructs a XiLensError object with a specific error code and associated error message.
+     *
+     * @param code The error code indicating the type of error. Default value is Code::None.
+     * @param message A human-readable message providing additional details about the error. Default value is an empty
+     * string.
+     * @return An instance of XiLensError initialized with the provided code and message.
+     */
+    explicit XiLensError(const Code code = Code::None, const std::string &message = "")
+        : m_code(code), m_message(message)
+    {
+    }
+
+    /**
+     * @brief Queries the error code.
+     *
+     * @return TThe error code.
+     */
+    Code code() const
+    {
+        return m_code;
+    }
+
+    /**
+     * @brief Queries the error message corresponding to the error.
+     *
+     * @return error message.
+     */
+    const std::string &message() const
+    {
+        return m_message;
+    }
+
+    /**
+     * @brief Converts error code and additional message into a human-readable string.
+     *
+     * @return human readable error code representation + additional error message.
+     */
+    std::string toString() const
+    {
+        return errorCodeToString(m_code) + " " + m_message;
+    }
+
+    /**
+     * @brief Converts an error code into a string representation.
+     *
+     * @param code error code.
+     * @return string representation of the error code.
+     */
+    static std::string errorCodeToString(const Code code)
+    {
+        switch (code)
+        {
+        case Code::FileInconsistentMetadata:
+            return "File metadata is missing or has inconsistent shape.";
+        default:
+            return "Unknown";
+        }
+    }
+
+  private:
+    /**
+     * @brief The error code.
+     */
+    Code m_code;
+
+    /**
+     * @brief The error message.
+     */
+    std::string m_message;
+};
+#endif // ERRORS_H

--- a/src/imageContainer.cpp
+++ b/src/imageContainer.cpp
@@ -18,7 +18,7 @@ ImageContainer::ImageContainer() : m_PollImage(true)
     m_Image.size = sizeof(XI_IMG);
 }
 
-void ImageContainer::Initialize(std::shared_ptr<XiAPIWrapper> apiWrapper)
+void ImageContainer::Initialize(const std::shared_ptr<XiAPIWrapper> &apiWrapper)
 {
     this->m_apiWrapper = apiWrapper;
 }
@@ -44,7 +44,7 @@ ImageContainer::~ImageContainer()
     LOG_XILENS(info) << "Destroying image container";
 }
 
-void ImageContainer::PollImage(HANDLE *cameraHandle, int pollingRate)
+void ImageContainer::PollImage(const HANDLE *cameraHandle, const int pollingRate)
 {
     static unsigned lastImageId = 0;
     static int stat;
@@ -64,6 +64,7 @@ void ImageContainer::PollImage(HANDLE *cameraHandle, int pollingRate)
                 {
                     this->StopPolling();
                     LOG_XILENS(error) << "Error while trying to get image from device";
+                    LOG_XILENS(error) << "Error message: " << e.what();
                     this->CloseFile();
                     throw;
                 }

--- a/src/imageContainer.h
+++ b/src/imageContainer.h
@@ -50,7 +50,7 @@ class ImageContainer : public QObject
      *
      * @param apiWrapper
      */
-    void Initialize(std::shared_ptr<XiAPIWrapper> apiWrapper);
+    void Initialize(const std::shared_ptr<XiAPIWrapper> &apiWrapper);
 
     /**
      * It initializes the file object that will be used to store the data.
@@ -84,7 +84,7 @@ class ImageContainer : public QObject
      * @param cameraHandle The handle to the camera device.
      * @param pollingRate The polling rate in milliseconds.
      */
-    void PollImage(HANDLE *cameraHandle, int pollingRate);
+    void PollImage(const HANDLE *cameraHandle, int pollingRate);
 
     /**
      * Queries current imag ein container

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -337,6 +337,11 @@ void MainWindow::ShowErrorDialog(const QString &text, const QString &informative
 
 void MainWindow::HandleSnapshotButtonClicked()
 {
+    const auto invalidFileName = HandleFileNameSnapshotsLineEditTextEdited(this->ui->fileNameSnapshotsLineEdit->text());
+    if (invalidFileName)
+    {
+        return;
+    }
     m_snapshotsThread = boost::thread(&MainWindow::RecordSnapshots, this);
 }
 
@@ -1047,22 +1052,18 @@ void MainWindow::HandleLogTextLineEditReturnPressed()
 
 void MainWindow::HandleFileNameLineEditTextEdited(const QString &newText)
 {
-    m_fileName = ui->fileNameLineEdit->text();
+    m_fileName = newText;
 }
 
-void MainWindow::HandleFileNameSnapshotsLineEditTextEdited(const QString &newText)
+int MainWindow::HandleFileNameSnapshotsLineEditTextEdited(const QString &newText)
 {
-    if (m_fileName == ui->fileNameSnapshotsLineEdit->text())
+    if (m_fileName == newText)
     {
-        QMessageBox msgBox;
-        msgBox.setIcon(QMessageBox::Critical);
-        msgBox.setWindowTitle("Error");
-        msgBox.setText("<b>Invalid file name.</b>");
-        msgBox.setInformativeText("Snapshot file name cannot be the same as video recording file name.");
-        msgBox.exec();
-        return;
+        ShowErrorDialog("Invalid file name.", "Snapshot file name cannot be the same as video recording file name.");
+        return 1;
     }
-    m_snapshotsFileName = ui->fileNameSnapshotsLineEdit->text();
+    m_snapshotsFileName = newText;
+    return 0;
 }
 
 void MainWindow::HandleLogTextLineEditTextEdited(const QString &newText)
@@ -1072,7 +1073,7 @@ void MainWindow::HandleLogTextLineEditTextEdited(const QString &newText)
 
 void MainWindow::HandleBaseFolderLineEditTextEdited(const QString &newText)
 {
-    m_baseFolderPath = ui->baseFolderLineEdit->text();
+    m_baseFolderPath = newText;
 }
 
 void MainWindow::HandleViewerFileLineEditTextEdited(const QString &newText)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -21,6 +21,7 @@
 
 #include "constants.h"
 #include "displayFunctional.h"
+#include "errors.h"
 #include "imageContainer.h"
 #include "logger.h"
 #include "mainwindow.h"
@@ -253,9 +254,8 @@ MainWindow::~MainWindow()
 
 void MainWindow::RecordSnapshots()
 {
-    int nr_images = ui->nSnapshotsSpinBox->value();
-    QMetaObject::invokeMethod(ui->nSnapshotsSpinBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
-    QMetaObject::invokeMethod(ui->fileNameSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
+    const int nrImages = ui->nSnapshotsSpinBox->value();
+    ToggleSnapshotUI(false);
 
     std::string fileName = ui->fileNameSnapshotsLineEdit->text().toUtf8().constData();
 
@@ -263,25 +263,76 @@ void MainWindow::RecordSnapshots()
     {
         fileName = m_fileName.toUtf8().constData();
     }
-    QString filePath = GetFullFilenameStandardFormat(std::move(fileName), ".b2nd", "");
-    auto image = m_imageContainer.GetCurrentImage();
-    FileImage snapshotsFile(filePath.toStdString().c_str(), image.height, image.width);
-
-    for (int i = 0; i < nr_images; i++)
+    const QString filePath = GetFullFilenameStandardFormat(std::move(fileName), ".b2nd", "");
+    const auto snapshotsFile = OpenFileForSnapshots(filePath);
+    if (!snapshotsFile)
     {
-        int exp_time = m_cameraInterface.m_camera->GetExposureMs();
-        int waitTime = 2 * exp_time;
-        WaitMilliseconds(waitTime);
-        image = m_imageContainer.GetCurrentImage();
-        snapshotsFile.WriteImageData(image, GetCameraTemperature());
-        int progress = static_cast<int>((static_cast<float>(i + 1) / static_cast<float>(nr_images)) * 100);
-        QMetaObject::invokeMethod(ui->progressBar, "setValue", Qt::QueuedConnection, Q_ARG(int, progress));
+        // If the file couldn't be opened, restore UI and exit
+        ResetSnapshotUI();
+        return;
     }
-    snapshotsFile.AppendMetadata();
+
+    for (int i = 0; i < nrImages; i++)
+    {
+        CaptureAndStoreSnapshotImage(*snapshotsFile, i, nrImages);
+    }
+    snapshotsFile->AppendMetadata();
     LOG_XILENS(info) << "Closed snapshot recording file";
+    ResetSnapshotUI();
+}
+
+std::unique_ptr<FileImage> MainWindow::OpenFileForSnapshots(const QString &filePath)
+{
+    auto image = m_imageContainer.GetCurrentImage();
+    try
+    {
+        return std::make_unique<FileImage>(filePath.toStdString().c_str(), image.height, image.width);
+    }
+    catch (const XiLensError &error)
+    {
+        LOG_XILENS(error) << "Could not open snapshot recording file: " << filePath.toStdString();
+
+        // Use a helper for showing error dialogs
+        ShowErrorDialog("Invalid file name.", error.toString().data());
+        return nullptr; // Return nullptr to indicate failure
+    }
+}
+
+void MainWindow::CaptureAndStoreSnapshotImage(FileImage &snapshotsFile, int currentIndex, int totalImages)
+{
+    const int exposure = m_cameraInterface.m_camera->GetExposureMs();
+    const int waitTime = 2 * exposure;
+    WaitMilliseconds(waitTime);
+
+    // Capture the current image
+    const auto image = m_imageContainer.GetCurrentImage();
+    snapshotsFile.WriteImageData(image, GetCameraTemperature());
+
+    // Update progress bar
+    const int progress = static_cast<int>((currentIndex + 1) * 100.0 / totalImages);
+    QMetaObject::invokeMethod(ui->progressBar, "setValue", Qt::QueuedConnection, Q_ARG(int, progress));
+}
+
+void MainWindow::ToggleSnapshotUI(const bool enabled) const
+{
+    QMetaObject::invokeMethod(ui->nSnapshotsSpinBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, enabled));
+    QMetaObject::invokeMethod(ui->fileNameSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, enabled));
+}
+
+void MainWindow::ResetSnapshotUI() const
+{
     QMetaObject::invokeMethod(ui->progressBar, "setValue", Qt::QueuedConnection, Q_ARG(int, 0));
-    QMetaObject::invokeMethod(ui->nSnapshotsSpinBox, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
-    QMetaObject::invokeMethod(ui->fileNameSnapshotsLineEdit, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, true));
+    ToggleSnapshotUI(true);
+}
+
+void MainWindow::ShowErrorDialog(const QString &text, const QString &informativeText)
+{
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Critical);
+    msgBox.setWindowTitle("Error");
+    msgBox.setText("<b>" + text + "</b>");
+    msgBox.setInformativeText(informativeText);
+    msgBox.exec();
 }
 
 void MainWindow::HandleSnapshotButtonClicked()
@@ -465,9 +516,8 @@ void MainWindow::UpdateExposure()
     ui->exposureSlider->setValue(exp_ms);
 }
 
-void MainWindow::HandleRecordButtonClicked(bool clicked)
+void MainWindow::HandleRecordButtonClicked(const bool clicked)
 {
-    static QString original_colour;
     static QString original_button_text;
 
     if (clicked)
@@ -477,9 +527,18 @@ void MainWindow::HandleRecordButtonClicked(bool clicked)
                              .arg(this->m_cameraInterface.m_cameraIdentifier, this->m_cameraInterface.m_cameraSN),
                          LOG_FILE_NAME, true);
         this->m_elapsedTimer.start();
-        this->StartRecording();
+        try
+        {
+            this->StartRecording();
+        }
+        catch (const XiLensError &error)
+        {
+            this->LogMessage(" ERROR WHILE STARTING RECORDING", LOG_FILE_NAME, true);
+            this->LogMessage(error.what(), LOG_FILE_NAME, true);
+            QMetaObject::invokeMethod(ui->recordButton, "setChecked", Qt::QueuedConnection, Q_ARG(bool, false));
+            return;
+        }
         this->HandleElementsWhileRecording(clicked);
-        original_colour = ui->recordButton->styleSheet();
         original_button_text = ui->recordButton->text();
         // button text seems to be an object property and cannot be changed by using
         // QMetaObject::invokeMethod
@@ -647,7 +706,17 @@ void MainWindow::InitializeImageFileRecorder(std::string subFolder, std::string 
         fileName = m_fileName.toUtf8().constData();
     }
     QString fullPath = GetFullFilenameStandardFormat(std::move(fileName), ".b2nd", std::move(subFolder));
-    this->m_imageContainer.InitializeFile(fullPath.toStdString().c_str());
+    try
+    {
+        this->m_imageContainer.InitializeFile(fullPath.toStdString().c_str());
+    }
+    catch (const XiLensError &error)
+    {
+        LOG_XILENS(error) << "Error while initializing image file: " << fullPath.toStdString() << " "
+                          << error.toString();
+        ShowErrorDialog("Invalid file name.", error.toString().data());
+        throw;
+    }
 }
 
 void MainWindow::RecordImage(bool ignoreSkipping)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3,18 +3,14 @@
  * License: see LICENSE.md file
  *******************************************************/
 #include <QCloseEvent>
-#include <QDateTime>
-#include <QDir>
 #include <QFileDialog>
 #include <QGraphicsItem>
-#include <QGraphicsScene>
 #include <QMessageBox>
 #include <QTextStream>
 #include <b2nd.h>
 #include <boost/chrono.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
-#include <iostream>
 #include <opencv2/core/types_c.h>
 #include <string>
 #include <utility>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -26,11 +26,11 @@
 #include "xiAPIWrapper.h"
 
 MainWindow::MainWindow(QWidget *parent, const std::shared_ptr<XiAPIWrapper> &xiAPIWrapper)
-    : QMainWindow(parent), ui(new Ui::MainWindow), m_IOService(), m_temperatureIOService(),
-      m_temperatureIOWork(new boost::asio::io_service::work(m_temperatureIOService)), m_cameraInterface(),
-      m_recordedCount(0), m_testMode(g_commandLineArguments.test_mode), m_imageCounter(0), m_skippedCounter(0),
-      m_elapsedTimeTextStream(&m_elapsedTimeText), m_elapsedTime(0), m_viewerThreadRunning(true),
-      m_viewerThread(&MainWindow::ViewerWorkerThreadFunc, this)
+    : QMainWindow(parent), ui(new Ui::MainWindow), m_elapsedTime(0), m_elapsedTimeTextStream(&m_elapsedTimeText),
+      m_cameraInterface(), m_testMode(g_commandLineArguments.test_mode),
+      m_viewerThread(&MainWindow::ViewerWorkerThreadFunc, this), m_viewerThreadRunning(true), m_IOService(),
+      m_temperatureIOService(), m_temperatureIOWork(new boost::asio::io_service::work(m_temperatureIOService)),
+      m_recordedCount(0), m_imageCounter(0), m_skippedCounter(0)
 {
     this->m_xiAPIWrapper = xiAPIWrapper == nullptr ? this->m_xiAPIWrapper : xiAPIWrapper;
     m_cameraInterface.Initialize(this->m_xiAPIWrapper);
@@ -118,7 +118,7 @@ void MainWindow::SetUpConnections()
                                               &MainWindow::UpdateSaturationPercentageLCDDisplays));
 }
 
-void MainWindow::HandleConnectionResult(bool status, const char *file, int line, const char *func)
+void MainWindow::HandleConnectionResult(const bool status, const char *file, const int line, const char *func)
 {
     if (!status)
     {
@@ -161,13 +161,12 @@ void MainWindow::StopImageAcquisition()
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "misc-no-recursion"
-void MainWindow::EnableWidgetsInLayout(QLayout *layout, bool enable)
+void MainWindow::EnableWidgetsInLayout(const QLayout *layout, const bool enable)
 {
     for (int i = 0; i < layout->count(); ++i)
     {
-        QLayout *subLayout = layout->itemAt(i)->layout();
-        QWidget *widget = layout->itemAt(i)->widget();
-        if (widget)
+        const QLayout *subLayout = layout->itemAt(i)->layout();
+        if (const auto widget = layout->itemAt(i)->widget())
         {
             widget->setEnabled(enable);
         }
@@ -179,16 +178,16 @@ void MainWindow::EnableWidgetsInLayout(QLayout *layout, bool enable)
 }
 #pragma clang diagnostic pop
 
-void MainWindow::EnableUi(bool enable)
+void MainWindow::EnableUi(const bool enable)
 {
-    QLayout *layout = ui->mainUiVerticalLayout->layout();
+    const QLayout *layout = ui->mainUiVerticalLayout->layout();
     EnableWidgetsInLayout(layout, enable);
     SetGraphicsViewScene();
     this->ui->exposureSlider->setEnabled(enable);
     this->ui->logTextLineEdit->setEnabled(enable);
 }
 
-void MainWindow::SetUpCustomUiComponents()
+void MainWindow::SetUpCustomUiComponents() const
 {
     // reload camera list button
     QIcon reloadButtonIcon;
@@ -210,9 +209,7 @@ void MainWindow::Display()
     boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
 
     // display new images with at most every 35ms
-    bool display_new = (now - last).total_milliseconds() > 35;
-
-    if (display_new)
+    if ((now - last).total_milliseconds() > 35)
     {
         // first get the pointer to the image to display
         XI_IMG image = m_imageContainer.GetCurrentImage();
@@ -294,7 +291,7 @@ std::unique_ptr<FileImage> MainWindow::OpenFileForSnapshots(const QString &fileP
     }
 }
 
-void MainWindow::CaptureAndStoreSnapshotImage(FileImage &snapshotsFile, int currentIndex, int totalImages)
+void MainWindow::CaptureAndStoreSnapshotImage(FileImage &snapshotsFile, const int currentIndex, const int totalImages)
 {
     const int exposure = m_cameraInterface.m_camera->GetExposureMs();
     const int waitTime = 2 * exposure;
@@ -348,9 +345,9 @@ QMap<QString, float> MainWindow::GetCameraTemperature() const
     return cameraTemperature;
 }
 
-void MainWindow::DisplayCameraTemperature()
+void MainWindow::DisplayCameraTemperature() const
 {
-    double temp = m_cameraInterface.m_camera->m_cameraFamily->get()->m_cameraTemperature.value(SENSOR_BOARD_TEMP);
+    const double temp = m_cameraInterface.m_camera->m_cameraFamily->get()->m_cameraTemperature.value(SENSOR_BOARD_TEMP);
     QMetaObject::invokeMethod(ui->temperatureLCDNumber, "display", Qt::QueuedConnection, Q_ARG(double, temp));
 }
 
@@ -376,8 +373,9 @@ void MainWindow::HandleTemperatureTimer(const boost::system::error_code &error)
 
     // Reset timer
     m_temperatureThreadTimer->expires_after(std::chrono::seconds(TEMP_LOG_INTERVAL));
-    m_temperatureThreadTimer->async_wait(
-        [this](const boost::system::error_code &error) { this->HandleTemperatureTimer(error); });
+    m_temperatureThreadTimer->async_wait([this](const boost::system::error_code &errorTemperatureTimer) {
+        this->HandleTemperatureTimer(errorTemperatureTimer);
+    });
 }
 
 void MainWindow::StartTemperatureThread()
@@ -388,7 +386,7 @@ void MainWindow::StartTemperatureThread()
     {
         StopTemperatureThread();
     }
-    m_temperatureThread = boost::thread([&]() {
+    m_temperatureThread = boost::thread([&] {
         ScheduleTemperatureThread();
         m_temperatureIOService.reset();
         m_temperatureIOService.run();
@@ -428,47 +426,47 @@ void MainWindow::StopReferenceRecordingThread()
     }
 }
 
-void MainWindow::HandleExposureValueChanged(int value)
+void MainWindow::HandleExposureValueChanged(const int value)
 {
     m_cameraInterface.m_camera->SetExposureMs(value);
     UpdateExposure();
 }
 
-void MainWindow::HandleViewerImageSliderValueChanged(int value)
+void MainWindow::HandleViewerImageSliderValueChanged(const int value)
 {
     {
-        boost::lock_guard<boost::mutex> lock(m_mutexImageViewer);
+        boost::lock_guard lock(m_mutexImageViewer);
         m_viewerSliderQueue.push(value);
     }
     m_viewerQueueCondition.notify_one();
 }
 
-void MainWindow::ProcessViewerImageSliderValueChanged(int value)
+void MainWindow::ProcessViewerImageSliderValueChanged(const int value)
 {
-    std::array<int64_t, B2ND_MAX_DIM> slice_start = {0};
-    std::array<int64_t, B2ND_MAX_DIM> slice_stop = {0};
-    std::array<int64_t, B2ND_MAX_DIM> slice_shape = {0};
+    std::array<int64_t, B2ND_MAX_DIM> slice_start = {};
+    std::array<int64_t, B2ND_MAX_DIM> slice_stop = {};
+    std::array<int64_t, B2ND_MAX_DIM> slice_shape = {};
     for (int i = 0; i < this->m_viewerNDArray->ndim; i++)
     {
         slice_start[i] = i == 0 ? value : 0;
         slice_stop[i] = i == 0 ? value + 1 : this->m_viewerNDArray->shape[i];
         slice_shape[i] = slice_stop[i] - slice_start[i];
     }
-    auto buffer_size =
+    const auto buffer_size =
         static_cast<int64_t>(this->m_viewerNDArray->shape[1] * this->m_viewerNDArray->shape[2] * sizeof(uint16_t));
     std::vector<uint16_t> buffer(this->m_viewerNDArray->shape[1] * this->m_viewerNDArray->shape[2]);
     b2nd_get_slice_cbuffer(this->m_viewerNDArray, slice_start.data(), slice_stop.data(), buffer.data(),
                            slice_shape.data(), buffer_size);
 
     // Get image dimensions, dimensions are transposed compared to what OpenCv expects.
-    auto width = static_cast<int>(slice_shape[1]);
-    auto height = static_cast<int>(slice_shape[2]);
+    const auto width = static_cast<int>(slice_shape[1]);
+    const auto height = static_cast<int>(slice_shape[2]);
     cv::Mat mat(width, height, CV_16UC1, buffer.data());
     mat /= 4;
     mat.convertTo(mat, CV_8UC1);
 
     // Indicate that processing is finished.
-    auto viewerQImage = GetQImageFromMatrix(mat, QImage::Format_Grayscale8);
+    const auto viewerQImage = GetQImageFromMatrix(mat, QImage::Format_Grayscale8);
     emit ViewerImageProcessingComplete(viewerQImage);
 }
 
@@ -480,7 +478,7 @@ void MainWindow::ViewerWorkerThreadFunc()
         int value = -1; // Default invalid value
 
         {
-            boost::unique_lock<boost::mutex> lock(m_mutexImageViewer);
+            boost::unique_lock lock(m_mutexImageViewer);
             m_viewerQueueCondition.wait(lock,
                                         [this]() { return !m_viewerSliderQueue.empty() || !m_viewerThreadRunning; });
 
@@ -503,18 +501,18 @@ void MainWindow::ViewerWorkerThreadFunc()
     }
 }
 
-void MainWindow::UpdateExposure()
+void MainWindow::UpdateExposure() const
 {
     // lock ui elements before updating them
     const QSignalBlocker exposureSliderLock(ui->exposureSlider);
     const QSignalBlocker exposureSpinBoxLock(ui->exposureSpinBox);
-    int exp_ms = m_cameraInterface.m_camera->GetExposureMs();
+    const int exposureMilliseconds = m_cameraInterface.m_camera->GetExposureMs();
     // update the estimated framerate
-    int n_skip_frames = ui->skipFramesSpinBox->value();
-    ui->hzLabel->setText(QString::number((double)(1000.0 / (exp_ms * (n_skip_frames + 1))), 'g', 2));
+    const int nrSkipFrames = ui->skipFramesSpinBox->value();
+    ui->hzLabel->setText(QString::number(1000.0 / (exposureMilliseconds * (nrSkipFrames + 1)), 'g', 2));
     // set exposure values to bot spinbox and slider
-    ui->exposureSpinBox->setValue(exp_ms);
-    ui->exposureSlider->setValue(exp_ms);
+    ui->exposureSpinBox->setValue(exposureMilliseconds);
+    ui->exposureSlider->setValue(exposureMilliseconds);
 }
 
 void MainWindow::HandleRecordButtonClicked(const bool clicked)
@@ -554,7 +552,7 @@ void MainWindow::HandleRecordButtonClicked(const bool clicked)
     }
 }
 
-void MainWindow::HandleElementsWhileRecording(bool recordingInProgress)
+void MainWindow::HandleElementsWhileRecording(const bool recordingInProgress) const
 {
     if (recordingInProgress)
     {
@@ -612,7 +610,7 @@ void MainWindow::HandleBaseFolderButtonClicked()
 
 void MainWindow::HandleViewerFileButtonClicked()
 {
-    QString filePath = QFileDialog::getOpenFileName(this, tr("Open File"), "", tr("NDArrays (*.b2nd)"));
+    const QString filePath = QFileDialog::getOpenFileName(this, tr("Open File"), "", tr("NDArrays (*.b2nd)"));
     if (QFile(filePath).exists())
     {
         if (!filePath.isEmpty())
@@ -628,15 +626,15 @@ void MainWindow::HandleViewerFileButtonClicked()
 
 void MainWindow::OpenFileInViewer(const QString &filePath)
 {
-    char *path = strdup(filePath.toUtf8().constData());
+    const char *path = strdup(filePath.toUtf8().constData());
     b2nd_open(path, &this->m_viewerNDArray);
-    auto n_images = static_cast<int>(this->m_viewerNDArray->shape[0] - 1);
-    int defaultIndex = 0;
+    const auto nrImages = static_cast<int>(this->m_viewerNDArray->shape[0] - 1);
+    constexpr int defaultIndex = 0;
     // only enable slider when more than one image is in the file
-    if (n_images != 0)
+    if (nrImages != 0)
     {
         this->ui->viewerImageSlider->setEnabled(true);
-        this->ui->viewerImageSlider->setMaximum(n_images);
+        this->ui->viewerImageSlider->setMaximum(nrImages);
     }
     else
     {
@@ -646,21 +644,21 @@ void MainWindow::OpenFileInViewer(const QString &filePath)
     this->HandleViewerImageSliderValueChanged(defaultIndex);
 }
 
-void MainWindow::WriteLogHeader()
+void MainWindow::WriteLogHeader() const
 {
-    auto version =
+    const auto version =
         QString(" XILENS Version: %1.%2.%3").arg(PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR, PROJECT_VERSION_PATCH);
-    auto hash = " git hash: " + QString(GIT_COMMIT);
-    this->LogMessage(hash, LOG_FILE_NAME, true);
-    this->LogMessage(version, LOG_FILE_NAME, true);
+    const auto hash = " git hash: " + QString(GIT_COMMIT);
+    (void)this->LogMessage(hash, LOG_FILE_NAME, true);
+    (void)this->LogMessage(version, LOG_FILE_NAME, true);
 }
 
-QString MainWindow::GetLogFilePath(const QString &logFile)
+QString MainWindow::GetLogFilePath(const QString &logFile) const
 {
     return QDir::cleanPath(ui->baseFolderLineEdit->text() + QDir::separator() + logFile);
 }
 
-QString MainWindow::LogMessage(const QString &message, const QString &logFile, bool logTime)
+QString MainWindow::LogMessage(const QString &message, const QString &logFile, const bool logTime) const
 {
     auto timestamp = GetTimeStamp();
     QFile file(this->GetLogFilePath(logFile));
@@ -706,7 +704,7 @@ void MainWindow::InitializeImageFileRecorder(std::string subFolder, std::string 
     {
         fileName = m_fileName.toUtf8().constData();
     }
-    QString fullPath = GetFullFilenameStandardFormat(std::move(fileName), ".b2nd", std::move(subFolder));
+    const QString fullPath = GetFullFilenameStandardFormat(std::move(fileName), ".b2nd", std::move(subFolder));
     try
     {
         this->m_imageContainer.InitializeFile(fullPath.toStdString().c_str());
@@ -720,19 +718,18 @@ void MainWindow::InitializeImageFileRecorder(std::string subFolder, std::string 
     }
 }
 
-void MainWindow::RecordImage(bool ignoreSkipping)
+void MainWindow::RecordImage(const bool ignoreSkipping)
 {
     boost::this_thread::interruption_point();
-    XI_IMG image = m_imageContainer.GetCurrentImage();
-    boost::lock_guard<boost::mutex> guard(this->m_mutexImageRecording);
-    static long lastImageID = image.acq_nframe;
-    int nSkipFrames = ui->skipFramesSpinBox->value();
-    if (MainWindow::ImageShouldBeRecorded(nSkipFrames, image.acq_nframe) || ignoreSkipping)
+    const XI_IMG image = m_imageContainer.GetCurrentImage();
+    boost::lock_guard guard(this->m_mutexImageRecording);
+    const int nSkipFrames = ui->skipFramesSpinBox->value();
+    if (ImageShouldBeRecorded(nSkipFrames, image.acq_nframe) || ignoreSkipping)
     {
         try
         {
             this->m_imageContainer.m_imageFile->WriteImageData(image, GetCameraTemperature());
-            m_recordedCount++;
+            ++m_recordedCount;
         }
         catch (const std::runtime_error &e)
         {
@@ -744,14 +741,13 @@ void MainWindow::RecordImage(bool ignoreSkipping)
     }
     else
     {
-        m_skippedCounter++;
+        ++m_skippedCounter;
     }
-    lastImageID = image.acq_nframe;
 }
 
 void MainWindow::RegisterTimeImageRecorded()
 {
-    auto now = std::chrono::steady_clock::now();
+    const auto now = std::chrono::steady_clock::now();
     m_recordedTimestamps.push_back(now);
     if (m_recordedTimestamps.size() > MAX_FRAMES_TO_COMPUTE_FPS)
     {
@@ -759,12 +755,12 @@ void MainWindow::RegisterTimeImageRecorded()
     }
 }
 
-bool MainWindow::ImageShouldBeRecorded(int nSkipFrames, long ImageID)
+bool MainWindow::ImageShouldBeRecorded(const int nSkipFrames, const long ImageID)
 {
-    return (nSkipFrames == 0) || (ImageID % nSkipFrames == 0);
+    return nSkipFrames == 0 || ImageID % nSkipFrames == 0;
 }
 
-void MainWindow::DisplayRecordCount()
+void MainWindow::DisplayRecordCount() const
 {
     QMetaObject::invokeMethod(ui->recordedImagesLCDNumber, "display", Qt::QueuedConnection,
                               Q_ARG(int, static_cast<int>(m_recordedCount.load())));
@@ -773,10 +769,10 @@ void MainWindow::DisplayRecordCount()
 void MainWindow::UpdateTimer()
 {
     m_elapsedTime = static_cast<double>(m_elapsedTimer.elapsed()) / 1000.0;
-    int totalSeconds = static_cast<int>(m_elapsedTime);
-    int hours = totalSeconds / 3600;
-    int minutes = (totalSeconds % 3600) / 60;
-    int seconds = totalSeconds % 60;
+    const int totalSeconds = static_cast<int>(m_elapsedTime);
+    const int hours = totalSeconds / 3600;
+    const int minutes = (totalSeconds % 3600) / 60;
+    const int seconds = totalSeconds % 60;
     m_elapsedTimeText.clear();
     m_elapsedTimeTextStream.seek(0);
     m_elapsedTimeTextStream.setFieldWidth(2); // Set field width to 2 or numbers and 1 for separators
@@ -789,18 +785,18 @@ void MainWindow::UpdateTimer()
     m_elapsedTimeTextStream.setFieldWidth(1);
     m_elapsedTimeTextStream << ":";
     m_elapsedTimeTextStream.setFieldWidth(2);
-    m_elapsedTimeTextStream << static_cast<int>(seconds);
+    m_elapsedTimeTextStream << seconds;
     ui->timerLCDNumber->display(m_elapsedTimeText);
 }
 
-void MainWindow::StopTimer()
+void MainWindow::StopTimer() const
 {
     ui->timerLCDNumber->display(0);
 }
 
 void MainWindow::CountImages()
 {
-    m_imageCounter++;
+    ++m_imageCounter;
 }
 
 void MainWindow::StartRecording()
@@ -847,7 +843,7 @@ void MainWindow::StopRecording()
     LOG_XILENS(info) << "Estimate for frames skipped: " << m_skippedCounter;
 }
 
-QString MainWindow::GetWritingFolder()
+QString MainWindow::GetWritingFolder() const
 {
     QString writeFolder = GetBaseFolder();
     writeFolder += QDir::separator();
@@ -856,7 +852,7 @@ QString MainWindow::GetWritingFolder()
 
 void MainWindow::CreateFolderIfNecessary(const QString &folder)
 {
-    QDir folderDir(folder);
+    const QDir folderDir(folder);
 
     if (!folderDir.exists())
     {
@@ -868,14 +864,14 @@ void MainWindow::CreateFolderIfNecessary(const QString &folder)
 }
 
 QString MainWindow::GetFullFilenameStandardFormat(std::string &&fileName, const std::string &extension,
-                                                  std::string &&subFolder)
+                                                  std::string &&subFolder) const
 {
     QString writingFolder = GetWritingFolder() + QDir::separator() + QString::fromStdString(subFolder);
     if (!writingFolder.endsWith(QDir::separator()))
     {
         writingFolder += QDir::separator();
     }
-    MainWindow::CreateFolderIfNecessary(writingFolder);
+    CreateFolderIfNecessary(writingFolder);
 
     QString fullFileName;
     if (!m_testMode)
@@ -905,7 +901,7 @@ void MainWindow::StopPollingThread()
     m_imageContainerThread.join();
 }
 
-void MainWindow::HandleAutoexposureCheckboxClicked(bool setAutoexposure)
+void MainWindow::HandleAutoexposureCheckboxClicked(const bool setAutoexposure) const
 {
     this->m_cameraInterface.m_camera->AutoExposure(setAutoexposure);
     ui->exposureSlider->setEnabled(!setAutoexposure);
@@ -943,12 +939,12 @@ void MainWindow::RecordReferenceImages(const QString &referenceType)
         QMetaObject::invokeMethod(ui->whiteBalanceButton, "setEnabled", Qt::QueuedConnection, Q_ARG(bool, false));
     }
 
-    QString baseFolder = ui->baseFolderLineEdit->text();
-    QDir dir(baseFolder);
+    const QString baseFolder = ui->baseFolderLineEdit->text();
+    const QDir dir(baseFolder);
     QStringList nameFilters;
     nameFilters << referenceType + "*";
     QStringList fileNameList = dir.entryList(nameFilters, QDir::Files | QDir::NoDotAndDotDot);
-    QRegularExpression re("^" + referenceType + "(\\d*)\\.[a-zA-Z0-9]+");
+    const QRegularExpression re("^" + referenceType + "(\\d*)\\.[a-zA-Z0-9]+");
 
     int fileNum = 0;
     for (const QString &fileName : fileNameList)
@@ -972,8 +968,8 @@ void MainWindow::RecordReferenceImages(const QString &referenceType)
     this->InitializeImageFileRecorder("", filename);
     for (int i = 0; i < NR_REFERENCE_IMAGES_TO_RECORD; i++)
     {
-        int exp_time = m_cameraInterface.m_camera->GetExposureMs();
-        int waitTime = 2 * exp_time;
+        const int exp_time = m_cameraInterface.m_camera->GetExposureMs();
+        const int waitTime = 2 * exp_time;
         WaitMilliseconds(waitTime);
         this->RecordImage(true);
         int progress = static_cast<int>((static_cast<float>(i + 1) / NR_REFERENCE_IMAGES_TO_RECORD) * 100);
@@ -1012,7 +1008,7 @@ void MainWindow::RestoreLineEditStyle(QLineEdit *lineEdit)
 
 void MainWindow::HandleViewerFileLineEditReturnPressed()
 {
-    auto file = QFile(ui->viewerFileLineEdit->text());
+    const auto file = QFile(ui->viewerFileLineEdit->text());
     if (file.exists())
     {
         m_viewerFilePath = ui->viewerFileLineEdit->text();
@@ -1027,14 +1023,13 @@ void MainWindow::HandleViewerFileLineEditReturnPressed()
 
 void MainWindow::HandleLogTextLineEditReturnPressed()
 {
-    QString timestamp;
     QString trigger_message = ui->logTextLineEdit->text();
     // block signals until method ends
     const QSignalBlocker triggerTextBlocker(ui->logTextLineEdit);
     const QSignalBlocker triggersTextEdit(ui->logTextEdit);
     // log message and update member variable for trigger text
     trigger_message.prepend(" ");
-    timestamp = this->LogMessage(trigger_message, LOG_FILE_NAME, true);
+    QString timestamp = this->LogMessage(trigger_message, LOG_FILE_NAME, true);
     timestamp = FormatTimeStamp(timestamp);
     m_triggerText = QString("<span style=\"color:gray;\">%1</span>").arg(timestamp) +
                     QString("<b>%1</b>").arg(trigger_message) + "\n";
@@ -1062,7 +1057,7 @@ int MainWindow::HandleFileNameSnapshotsLineEditTextEdited(const QString &newText
     return 0;
 }
 
-void MainWindow::HandleLogTextLineEditTextEdited(const QString &newText)
+void MainWindow::HandleLogTextLineEditTextEdited(const QString &newText) const
 {
     UpdateComponentEditedStyle(ui->logTextLineEdit, newText, m_triggerText);
 }
@@ -1072,14 +1067,14 @@ void MainWindow::HandleBaseFolderLineEditTextEdited(const QString &newText)
     m_baseFolderPath = newText;
 }
 
-void MainWindow::HandleViewerFileLineEditTextEdited(const QString &newText)
+void MainWindow::HandleViewerFileLineEditTextEdited(const QString &newText) const
 {
     UpdateComponentEditedStyle(ui->viewerFileLineEdit, newText, m_viewerFilePath);
 }
 
 QString MainWindow::FormatTimeStamp(const QString &timestamp)
 {
-    QDateTime dateTime = QDateTime::fromString(timestamp, "yyyyMMdd_HH-mm-ss-zzz");
+    const QDateTime dateTime = QDateTime::fromString(timestamp, "yyyyMMdd_HH-mm-ss-zzz");
     QString formattedDate = dateTime.toString("hh:mm:ss AP");
     return formattedDate;
 }
@@ -1088,19 +1083,19 @@ QString MainWindow::FormatTimeStamp(const QString &timestamp)
  * updates frames per second label in GUI when the number of skipped frames is
  * modified
  */
-void MainWindow::HandleSkipFramesSpinBoxValueChanged()
+void MainWindow::HandleSkipFramesSpinBoxValueChanged() const
 {
     // spin boxes do not have a returnPressed slot in Qt, which is why the value
     // is always updated upon changes
-    int exp_ms = m_cameraInterface.m_camera->GetExposureMs();
-    int nSkipFrames = ui->skipFramesSpinBox->value();
+    const int exposureMilliseconds = m_cameraInterface.m_camera->GetExposureMs();
+    const int nSkipFrames = ui->skipFramesSpinBox->value();
     const QSignalBlocker blocker_label(ui->hzLabel);
-    ui->hzLabel->setText(QString::number((double)(1000.0 / (exp_ms * (nSkipFrames + 1))), 'g', 2));
+    ui->hzLabel->setText(QString::number(1000.0 / (exposureMilliseconds * (nSkipFrames + 1)), 'g', 2));
 }
 
-void MainWindow::HandleCameraListComboBoxCurrentIndexChanged(int index)
+void MainWindow::HandleCameraListComboBoxCurrentIndexChanged(const int index)
 {
-    boost::lock_guard<boost::mutex> guard(m_mutexImageRecording);
+    boost::lock_guard guard(m_mutexImageRecording);
     // image acquisition should be stopped when index 0 (no camera) is selected
     // from the dropdown menu
     try
@@ -1114,13 +1109,13 @@ void MainWindow::HandleCameraListComboBoxCurrentIndexChanged(int index)
     }
     if (index != 0)
     {
-        QString cameraIdentifier = ui->cameraListComboBox->currentText();
-        QString cameraModel = cameraIdentifier.split("@").at(0);
+        const QString cameraIdentifier = ui->cameraListComboBox->currentText();
+        const QString cameraModel = cameraIdentifier.split("@").at(0);
         m_cameraInterface.m_cameraIdentifier = cameraIdentifier;
         if (getCameraMapper().contains(cameraModel))
         {
-            QString cameraType = getCameraMapper().value(cameraModel).cameraType;
-            QString originalCameraIdentifier = m_cameraInterface.m_cameraIdentifier;
+            const QString cameraType = getCameraMapper().value(cameraModel).cameraType;
+            const QString originalCameraIdentifier = m_cameraInterface.m_cameraIdentifier;
             try
             {
                 // set the camera type needed by the camera interface initialization
@@ -1131,6 +1126,7 @@ void MainWindow::HandleCameraListComboBoxCurrentIndexChanged(int index)
             catch (std::runtime_error &e)
             {
                 LOG_XILENS(error) << "could not start image acquisition for camera: " << cameraIdentifier.toStdString();
+                LOG_XILENS(error) << "error: " << e.what();
                 // restore camera type and index
                 m_display->SetCameraProperties(originalCameraIdentifier);
                 m_cameraInterface.SetCameraProperties(originalCameraIdentifier);
@@ -1197,8 +1193,8 @@ void MainWindow::HandleReloadCamerasPushButtonClicked()
     ui->reloadCamerasPushButton->setDown(false);
 }
 
-void MainWindow::UpdateSaturationPercentageLCDDisplays(double percentageBelowThreshold,
-                                                       double percentageAboveThreshold) const
+void MainWindow::UpdateSaturationPercentageLCDDisplays(const double percentageBelowThreshold,
+                                                       const double percentageAboveThreshold) const
 {
     QString displayValue = QString::number(percentageAboveThreshold, 'f', 1);
     QMetaObject::invokeMethod(ui->overexposurePercentageLCDNumber, "display", Qt::QueuedConnection,
@@ -1208,22 +1204,23 @@ void MainWindow::UpdateSaturationPercentageLCDDisplays(double percentageBelowThr
                               Q_ARG(QString, displayValue));
 }
 
-void MainWindow::UpdateFPSLCDDisplay()
+void MainWindow::UpdateFPSLCDDisplay() const
 {
     using namespace std::chrono;
     if (this->m_recordedTimestamps.size() < 2)
     {
         return;
     }
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(this->m_recordedTimestamps.back() -
-                                                                          this->m_recordedTimestamps.front())
-                        .count();
-    double fps = (static_cast<double>(this->m_recordedTimestamps.size()) - 1) * 1000.0 / static_cast<double>(duration);
-    QString displayValue = QString::number(fps, 'f', 1);
+    const auto duration =
+        std::chrono::duration_cast<milliseconds>(this->m_recordedTimestamps.back() - this->m_recordedTimestamps.front())
+            .count();
+    const double fps =
+        (static_cast<double>(this->m_recordedTimestamps.size()) - 1) * 1000.0 / static_cast<double>(duration);
+    const QString displayValue = QString::number(fps, 'f', 1);
     QMetaObject::invokeMethod(this->ui->fpsLCDNumber, "display", Qt::QueuedConnection, Q_ARG(QString, displayValue));
 }
 
-void MainWindow::UpdateImage(QImage image, QGraphicsView *view, std::unique_ptr<QGraphicsPixmapItem> &pixmapItem,
+void MainWindow::UpdateImage(QImage image, const QGraphicsView *view, std::unique_ptr<QGraphicsPixmapItem> &pixmapItem,
                              QGraphicsScene *scene)
 {
     image = image.scaled(view->width(), view->height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
@@ -1239,34 +1236,34 @@ void MainWindow::UpdateImage(QImage image, QGraphicsView *view, std::unique_ptr<
     }
 }
 
-void MainWindow::UpdateRGBImage(QImage image)
+void MainWindow::UpdateRGBImage(const QImage &image)
 {
     UpdateImage(image, this->ui->rgbImageGraphicsView, this->m_rgbPixMapItem, this->m_rgbScene.get());
 }
 
-void MainWindow::UpdateRawImage(QImage image)
+void MainWindow::UpdateRawImage(const QImage &image)
 {
     UpdateImage(image, this->ui->rawImageGraphicsView, this->m_rawPixMapItem, this->m_rawScene.get());
 }
 
-void MainWindow::UpdateRawViewerImage(QImage image)
+void MainWindow::UpdateRawViewerImage(const QImage &image)
 {
     UpdateImage(image, this->ui->viewerGraphicsView, this->m_rawViewerPixMapItem, this->m_rawViewerScene.get());
 }
 
-void MainWindow::SetGraphicsViewScene()
+void MainWindow::SetGraphicsViewScene() const
 {
     this->ui->rgbImageGraphicsView->setScene(this->m_rgbScene.get());
     this->ui->rawImageGraphicsView->setScene(this->m_rawScene.get());
     this->ui->viewerGraphicsView->setScene(this->m_rawViewerScene.get());
 }
 
-bool MainWindow::IsSaturationButtonChecked()
+bool MainWindow::IsSaturationButtonChecked() const
 {
     return this->ui->saturationToolButton->isChecked();
 }
 
-void MainWindow::SetRecordedCount(int count)
+void MainWindow::SetRecordedCount(const int count)
 {
     m_recordedCount = count;
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -7,13 +7,9 @@
 
 #include <QApplication>
 #include <QCloseEvent>
-#include <QElapsedTimer>
 #include <QGraphicsScene>
-#include <QGuiApplication>
-#include <QImage>
 #include <QLineEdit>
 #include <QMainWindow>
-#include <QScreen>
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -298,6 +298,8 @@ class MainWindow : public QMainWindow
      * is synchronized with the exposure time label.
      *
      * @param clicked indicates if the button is clicked.
+     *
+     * @throws XiLensError when an error occurs while trying to initialize the file for recording the data.
      */
     void HandleRecordButtonClicked(bool clicked);
 
@@ -494,6 +496,8 @@ class MainWindow : public QMainWindow
      *
      * @param subFolder folder where data will be stored.
      * @param fileName file name.
+     *
+     * @throws XiLensError when the initialization of the file cannot be completed.
      */
     void InitializeImageFileRecorder(std::string subFolder = "", std::string fileName = "");
 
@@ -518,14 +522,73 @@ class MainWindow : public QMainWindow
     void UpdateTimer();
 
     /**
-     * Stops the timer that is displayed in the UI when recordings are started.
+     * Stops the timer displayed in the UI when recordings are started.
      */
     void StopTimer();
 
     /**
-     * @brief MEthod used to record singe snapshot images while recording.
+     * @brief Method used to record a specific number of images.
+     *
+     * The main different to recording a video, this function records a specific number of images instead of a
+     * continuous stream.
+     * This method terminates after the specified number of images has been recorded.
      */
     void RecordSnapshots();
+
+    /**
+     * @brief Captures an image from the camera and stores it in the specified file, while updating the progress bar.
+     *
+     * This method performs the following operations:
+     * - Retrieves the camera's exposure time and calculates the wait time accordingly.
+     * - Captures the current image from the `m_imageContainer` and stores it in the specified `snapshotsFile`.
+     * - Updates the progress bar to reflect the percentage of images captured out of the total images.
+     *
+     * @param snapshotsFile A reference to the file where the captured image data will be stored.
+     * @param currentIndex The index of the current image being captured (used for progress calculation).
+     * @param totalImages The total number of images to be captured (used for progress calculation).
+     */
+    void CaptureAndStoreSnapshotImage(FileImage &snapshotsFile, int currentIndex, int totalImages);
+
+    /**
+     * @brief Opens a file for saving snapshot images and initializes the file with the current image's dimensions.
+     *
+     * This method attempts to create a new file to save snapshot images using the specified file path. It retrieves the
+     * height and width of the current image and initializes the file accordingly. If the operation fails, an error is
+     * logged, an error dialog is shown to the user, and a null pointer is returned.
+     *
+     * @param filePath The path of the file to be created for saving snapshot images.
+     * @return A unique pointer to the initialized `FileImage` object if successful, or a null pointer if the operation
+     * fails.
+     */
+    std::unique_ptr<FileImage> OpenFileForSnapshots(const QString &filePath);
+
+    /**
+     * @brief Display an error window with a title and message.
+     *
+     * @param text title of the error.
+     * @param informativeText additional error message to be displayed in the window.
+     */
+    static void ShowErrorDialog(const QString &text, const QString &informativeText);
+
+    /**
+     * @brief Enables or disables UI components related to snapshot functionality.
+     *
+     * This method adjusts the enabling state of UI components associated with the snapshot feature.
+     * It modifies the interaction capabilities of these components based on the provided parameter.
+     *
+     * @param enabled A boolean value indicating whether the snapshot-related UI components
+     * should be enabled (true) or disabled (false).
+     */
+    void ToggleSnapshotUI(bool enabled) const;
+
+    /**
+     * @brief Resets the state of the snapshot-related UI components.
+     *
+     * This method resets the snapshot UI to its initial state by setting the progress bar value to 0
+     * and re-enabling the snapshot UI components. It ensures the snapshot interface is properly
+     * prepared for a new operation or interaction.
+     */
+    void ResetSnapshotUI() const;
 
     /**
      * @brief UpdateExposure Synchronizes the sliders and text edits displaying
@@ -557,7 +620,6 @@ class MainWindow : public QMainWindow
      * format including timestamp etc.
      *
      * @param fileName the name of the file (snapshot, recording, liver_image, ...).
-     * @param frameNumber the acquisition frame number provided by ximea.
      * @param extension file extension (.b2nd).
      * @param subFolder sometimes we want to add an additional layer of subfolder.
      * specifically when saving white/dark balance images.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -78,7 +78,7 @@ class MainWindow : public QMainWindow
     /**
      * Configures custom UI elements such as custom icons in buttons, etc.
      */
-    void SetUpCustomUiComponents();
+    void SetUpCustomUiComponents() const;
 
     /**
      * Disables the UI elements.
@@ -86,12 +86,12 @@ class MainWindow : public QMainWindow
      * @param layout layout where elements will be enabled or disabled.
      * @param enable indicates if elements should ne enabled or disabled.
      */
-    void EnableWidgetsInLayout(QLayout *layout, bool enable);
+    static void EnableWidgetsInLayout(const QLayout *layout, bool enable);
 
     /**
      * Writes general information as header of the log file.
      */
-    void WriteLogHeader();
+    void WriteLogHeader() const;
 
     /**
      * Logs message to log file and returns the timestamp used during logging.
@@ -100,7 +100,7 @@ class MainWindow : public QMainWindow
      * @param logFile file name where the message should be logged.
      * @param logTime whether time should be logged too or not.
      */
-    QString LogMessage(const QString &message, const QString &logFile, bool logTime);
+    QString LogMessage(const QString &message, const QString &logFile, bool logTime) const;
 
     /**
      * Queries the path where the logfile is stored.
@@ -108,7 +108,7 @@ class MainWindow : public QMainWindow
      * @param logFile file name.
      * @return path to file.
      */
-    QString GetLogFilePath(const QString &logFile);
+    QString GetLogFilePath(const QString &logFile) const;
 
     /**
      * Gets camera temperature.
@@ -121,7 +121,7 @@ class MainWindow : public QMainWindow
     /**
      * Displays camera temperature on an LCD display.
      */
-    void DisplayCameraTemperature();
+    void DisplayCameraTemperature() const;
 
     /**
      * Creates schedule for the thread in charge of logging temperature of the camera.
@@ -153,14 +153,14 @@ class MainWindow : public QMainWindow
     /**
      * Updates the frames per second that are stored to file on the UI.
      */
-    void UpdateFPSLCDDisplay();
+    void UpdateFPSLCDDisplay() const;
 
     /**
      * Updates the raw image displayed in the viewer tab.
      *
      * @param image Qt image to display.
      */
-    void UpdateRawViewerImage(QImage image);
+    void UpdateRawViewerImage(const QImage &image);
 
     /**
      * Waits for the viewer thread to be running and for new values to be available in the queue. It emits a
@@ -177,7 +177,7 @@ class MainWindow : public QMainWindow
      * @param pixmapItem pixmap item where the image is to be placed.
      * @param scene the scene that will contain the pixmap.
      */
-    static void UpdateImage(QImage image, QGraphicsView *view, std::unique_ptr<QGraphicsPixmapItem> &pixmapItem,
+    static void UpdateImage(QImage image, const QGraphicsView *view, std::unique_ptr<QGraphicsPixmapItem> &pixmapItem,
                             QGraphicsScene *scene);
 
     /**
@@ -185,7 +185,7 @@ class MainWindow : public QMainWindow
      *
      * @return true if the saturation button is checked, false otherwise.
      */
-    bool IsSaturationButtonChecked();
+    bool IsSaturationButtonChecked() const;
 
     /**
      * Provides access to the applications user interface.
@@ -207,7 +207,7 @@ class MainWindow : public QMainWindow
     /**
      * Displays the number of recorded images in the GUI.
      */
-    void DisplayRecordCount();
+    void DisplayRecordCount() const;
 
   protected:
     /**
@@ -249,14 +249,14 @@ class MainWindow : public QMainWindow
      *
      * @param image Qt image containing an 8bit (per channel) RGB image to be displayed.
      */
-    void UpdateRGBImage(QImage image);
+    void UpdateRGBImage(const QImage &image);
 
     /**
      * Qt slot that updates the raw image displayed in the GUI.
      *
      * @param image Qt image containing an 8bit single channel image to be displayed.
      */
-    void UpdateRawImage(QImage image);
+    void UpdateRawImage(const QImage &image);
 
     /**
      * Qt slot that updates the saturation percentage on the LCD displays.
@@ -327,7 +327,7 @@ class MainWindow : public QMainWindow
      * Qt slot triggered when auto exposure checkbox is pressed. Handles control
      * of the exposure time to camera.
      */
-    void HandleAutoexposureCheckboxClicked(bool setAutoexposure);
+    void HandleAutoexposureCheckboxClicked(bool setAutoexposure) const;
 
     /**
      * Qt slot triggered when white balance button is pressed. Records a new white
@@ -347,7 +347,7 @@ class MainWindow : public QMainWindow
      *
      * @param newText edited text.
      */
-    void HandleLogTextLineEditTextEdited(const QString &newText);
+    void HandleLogTextLineEditTextEdited(const QString &newText) const;
 
     /**
      * Qt slot triggered when the return key is pressed on the trigger text field.
@@ -359,7 +359,7 @@ class MainWindow : public QMainWindow
      * Qt slot triggered when the spin box containing the number of images to skip
      * while recording is modified. It restyles the appearance of the field.
      */
-    void HandleSkipFramesSpinBoxValueChanged();
+    void HandleSkipFramesSpinBoxValueChanged() const;
 
     /**
      * Qt slot triggered when a new camera is selected from the drop-down menu.
@@ -393,7 +393,7 @@ class MainWindow : public QMainWindow
      *
      * @param newText edited text
      */
-    void HandleViewerFileLineEditTextEdited(const QString &newText);
+    void HandleViewerFileLineEditTextEdited(const QString &newText) const;
 
     /**
      * Qt slot triggered when the return key is pressed in the file path field of the viewer tab.
@@ -524,7 +524,7 @@ class MainWindow : public QMainWindow
     /**
      * Stops the timer displayed in the UI when recordings are started.
      */
-    void StopTimer();
+    void StopTimer() const;
 
     /**
      * @brief Method used to record a specific number of images.
@@ -594,7 +594,7 @@ class MainWindow : public QMainWindow
      * @brief UpdateExposure Synchronizes the sliders and text edits displaying
      * the current exposure setting.
      */
-    void UpdateExposure();
+    void UpdateExposure() const;
 
     /**
      * Enables and disables elements of the GUI that should not me modified while
@@ -602,7 +602,7 @@ class MainWindow : public QMainWindow
      *
      * @param recordingInProgress indicates if recordings are happening or not.
      */
-    void HandleElementsWhileRecording(bool recordingInProgress);
+    void HandleElementsWhileRecording(bool recordingInProgress) const;
 
     /**
      * @brief MainWindow::GetWritingFolder returns the folder there the image
@@ -610,7 +610,7 @@ class MainWindow : public QMainWindow
      *
      * @return folder where data is to be stored.
      */
-    QString GetWritingFolder();
+    QString GetWritingFolder() const;
 
     /**
      * @brief GetFullFilenameStandardFormat returns the full filename of the
@@ -626,7 +626,7 @@ class MainWindow : public QMainWindow
      * @return
      */
     QString GetFullFilenameStandardFormat(std::string &&fileName, const std::string &extension,
-                                          std::string &&subFolder);
+                                          std::string &&subFolder) const;
 
     /**
      * Queries the base folder path where data is to be stored.
@@ -674,7 +674,7 @@ class MainWindow : public QMainWindow
     /**
      * Sets the scene for RGB and raw image viewers. It defines antialiasing and smooth pixmap transformations.
      */
-    void SetGraphicsViewScene();
+    void SetGraphicsViewScene() const;
 
     /**
      * Appends the current time to que of recorded time stamps that can be used to calculate the frames per second.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -275,6 +275,9 @@ class MainWindow : public QMainWindow
     /**
      * Qt slot triggered when the snapshot button is pressed. Triggers the
      * recording of snapshot images or stops it when pressed a second time.
+     *
+     * If the name of the snapshot file is the same as the name of the file
+     * where a video is to be recorded, an error box is displayed.
      */
     void HandleSnapshotButtonClicked();
 
@@ -378,8 +381,9 @@ class MainWindow : public QMainWindow
      * Qt slot triggered when file name for snapshots is edited on the UI.
      *
      * @param newText edited text.
+     * @return 0 if file name is valid, 1 otherwise.
      */
-    void HandleFileNameSnapshotsLineEditTextEdited(const QString &newText);
+    int HandleFileNameSnapshotsLineEditTextEdited(const QString &newText);
 
     /**
      * Qt slot triggered when base folder field is edited in the UI.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -45,8 +45,7 @@ FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned in
     if (access(this->m_filePath, F_OK) != -1)
     {
         result = b2nd_open(this->m_filePath, &m_src);
-        auto metadataConsistent = CheckFileMetadata(m_src);
-        if (!metadataConsistent)
+        if (auto metadataConsistent = CheckFileMetadata(m_src); !metadataConsistent)
         {
             throw XiLensError(XiLensError::Code::FileInconsistentMetadata,
                               "You need to indicate a different file name.");
@@ -112,7 +111,8 @@ template <typename T> void PackAndAppendMetadata(b2nd_array_t *src, const char *
     catch (const std::runtime_error &err)
     {
         LOG_XILENS(error) << "Error while trying to add metadata for key: " << key;
-        throw err;
+        LOG_XILENS(error) << "Error message: " << err.what();
+        throw;
     }
 }
 
@@ -120,18 +120,18 @@ bool FileImage::CheckFileMetadata(const b2nd_array_t *src)
 {
     for (auto key : EXPECTED_METADATA_KEYS)
     {
-        auto nElements = GetBLOSCVLMetadataLength(src, key.toUtf8().constData());
-        if (nElements != src->shape[0])
+        const auto nrElements = GetBLOSCVLMetadataLength(src, key.toUtf8().constData());
+        if (nrElements != src->shape[0])
         {
             LOG_XILENS(error) << "Metadata key: " << key.toUtf8().constData()
-                              << " has inconsistent length: " << nElements << " vs expected: " << src->shape[0];
+                              << " has inconsistent length: " << nrElements << " vs expected: " << src->shape[0];
             return false;
         }
     }
     return true;
 }
 
-std::string ColorFilterToString(XI_COLOR_FILTER_ARRAY colorFilterArray)
+std::string ColorFilterToString(const XI_COLOR_FILTER_ARRAY colorFilterArray)
 {
     switch (colorFilterArray)
     {
@@ -223,8 +223,7 @@ void AppendBLOSCVLMetadata(b2nd_array_t *src, const char *key, msgpack::sbuffer 
     uint8_t *content = nullptr;
     int32_t content_len;
     int result;
-    int metadataExists = blosc2_vlmeta_exists(src->sc, key);
-    if (metadataExists < 0)
+    if (int metadataExists = blosc2_vlmeta_exists(src->sc, key); metadataExists < 0)
     {
         result = blosc2_vlmeta_add(src->sc, key, reinterpret_cast<uint8_t *>(newData.data()), newData.size(), nullptr);
         if (result < 0)
@@ -303,7 +302,7 @@ void AppendBLOSCVLMetadata(b2nd_array_t *src, const char *key, msgpack::sbuffer 
         }
 
         // Update the metadata with the new data
-        result = blosc2_vlmeta_update(src->sc, key, reinterpret_cast<uint8_t *>(sbuf.data()), sbuf.size(), NULL);
+        result = blosc2_vlmeta_update(src->sc, key, reinterpret_cast<uint8_t *>(sbuf.data()), sbuf.size(), nullptr);
         if (result < 0)
         {
             throw std::runtime_error("Error when using blosc2_vlmeta_update");
@@ -311,12 +310,12 @@ void AppendBLOSCVLMetadata(b2nd_array_t *src, const char *key, msgpack::sbuffer 
     }
 }
 
-void WaitMilliseconds(int milliseconds)
+void WaitMilliseconds(const int milliseconds)
 {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(milliseconds));
 }
 
-cv::Mat CreateLut(cv::Vec3b saturation_color, cv::Vec3b dark_color)
+cv::Mat CreateLut(const cv::Vec3b &saturation_color, const cv::Vec3b &dark_color)
 {
     cv::Mat Lut(1, 256, CV_8UC3);
     for (uint i = 0; i < 256; ++i)
@@ -334,18 +333,17 @@ cv::Mat CreateLut(cv::Vec3b saturation_color, cv::Vec3b dark_color)
     return Lut;
 }
 
-void XIIMGtoMat(XI_IMG &xi_img, cv::Mat &mat_img)
+void XIIMGtoMat(const XI_IMG &xi_img, cv::Mat &mat_img)
 {
     mat_img = cv::Mat(xi_img.height, xi_img.width, CV_16UC1, xi_img.bp);
 }
 
 QString GetTimeStamp()
 {
-    QString timestamp;
-    QString curr_time = (QTime::currentTime()).toString("hh-mm-ss-zzz");
-    QString date = (QDate::currentDate()).toString("yyyyMMdd_");
-    timestamp = date + curr_time;
+    const QString currentTime = QTime::currentTime().toString("hh-mm-ss-zzz");
+    const QString date = QDate::currentDate().toString("yyyyMMdd_");
+    QString timestamp = date + currentTime;
     return timestamp;
 }
 
-struct CommandLineArguments g_commandLineArguments;
+CommandLineArguments g_commandLineArguments;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,7 +6,6 @@
 
 #include <blosc2.h>
 
-#include <QDateTime>
 #include <boost/chrono.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/trivial.hpp>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "constants.h"
+#include "errors.h"
 #include "logger.h"
 
 FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned int imageWidth)
@@ -45,6 +46,12 @@ FileImage::FileImage(const char *filePath, unsigned int imageHeight, unsigned in
     if (access(this->m_filePath, F_OK) != -1)
     {
         result = b2nd_open(this->m_filePath, &m_src);
+        auto metadataConsistent = CheckFileMetadata(m_src);
+        if (!metadataConsistent)
+        {
+            throw XiLensError(XiLensError::Code::FileInconsistentMetadata,
+                              "You need to indicate a different file name.");
+        }
     }
     else
     {
@@ -110,6 +117,21 @@ template <typename T> void PackAndAppendMetadata(b2nd_array_t *src, const char *
     }
 }
 
+bool FileImage::CheckFileMetadata(const b2nd_array_t *src)
+{
+    for (auto key : EXPECTED_METADATA_KEYS)
+    {
+        auto nElements = GetBLOSCVLMetadataLength(src, key.toUtf8().constData());
+        if (nElements != src->shape[0])
+        {
+            LOG_XILENS(error) << "Metadata key: " << key.toUtf8().constData()
+                              << " has inconsistent length: " << nElements << " vs expected: " << src->shape[0];
+            return false;
+        }
+    }
+    return true;
+}
+
 std::string ColorFilterToString(XI_COLOR_FILTER_ARRAY colorFilterArray)
 {
     switch (colorFilterArray)
@@ -137,6 +159,65 @@ std::string ColorFilterToString(XI_COLOR_FILTER_ARRAY colorFilterArray)
     }
 }
 
+int GetBLOSCVLMetadataLength(const b2nd_array_t *src, const char *key)
+{
+    uint8_t *content = nullptr;
+    int32_t content_len = 0;
+    int nElements = 0;
+    if (int metadataExists = blosc2_vlmeta_exists(src->sc, key); metadataExists < 0)
+    {
+        LOG_XILENS(error) << "Error when trying to get metadata for key: " << key;
+        return metadataExists;
+    }
+    if (auto result = blosc2_vlmeta_get(src->sc, key, &content, &content_len); result < 0)
+    {
+        LOG_XILENS(error) << "Error when trying to get metadata for key: " << key;
+        return result;
+    }
+    msgpack::unpacker unpacker;
+    unpacker.reserve_buffer(content_len);
+    memcpy(unpacker.buffer(), content, content_len);
+    unpacker.buffer_consumed(content_len);
+    msgpack::object_handle oh;
+    unpacker.next(oh);
+
+    if (oh.get().type == msgpack::type::ARRAY && oh.get().via.array.size > 0)
+    {
+        switch (oh.get().via.array.ptr[0].type)
+        {
+        case msgpack::type::STR: {
+            // It's a vector of strings
+            auto dataUnpacked = oh.get().as<std::vector<std::string>>();
+            nElements = dataUnpacked.size();
+            break;
+        }
+        case msgpack::type::POSITIVE_INTEGER:
+        case msgpack::type::NEGATIVE_INTEGER: {
+            // It's a vector of ints
+            auto dataUnpacked = oh.get().as<std::vector<int>>();
+            nElements = dataUnpacked.size();
+            break;
+        }
+        case msgpack::type::FLOAT32:
+        case msgpack::type::FLOAT: {
+            // It's a vector of floats
+            auto dataUnpacked = oh.get().as<std::vector<float>>();
+            nElements = dataUnpacked.size();
+            break;
+        }
+        default: {
+            LOG_XILENS(error) << "Cannot handle MsgPack data type: " << oh.get().via.array.ptr[0].type;
+            throw std::runtime_error("Unhandled MsgPack type.");
+        }
+        }
+    }
+    else
+    {
+        throw std::runtime_error("Unexpected metadata type or empty array.");
+    }
+    return nElements;
+}
+
 void AppendBLOSCVLMetadata(b2nd_array_t *src, const char *key, msgpack::sbuffer &newData)
 {
     // Get the existing data
@@ -151,7 +232,6 @@ void AppendBLOSCVLMetadata(b2nd_array_t *src, const char *key, msgpack::sbuffer 
         {
             throw std::runtime_error("Error when using blosc2_vlmeta_add");
         }
-        return;
     }
     else
     {

--- a/src/util.h
+++ b/src/util.h
@@ -93,6 +93,8 @@ class FileImage
     /**
      * Opens a file and throws runtime error when opening fails
      * @param filePath path to file to open
+     * @param imageHeight height of image to store in file
+     * @param imageWidth width of image to store in file
      * @throws XiLensError when initializing file fails
      */
     FileImage(const char *filePath, unsigned int imageHeight, unsigned int imageWidth);
@@ -176,7 +178,7 @@ void WaitMilliseconds(int milliseconds);
  * @param dark_color color of pixels that are under-exposed
  * @return matrix with LUT
  */
-cv::Mat CreateLut(cv::Vec3b saturation_color, cv::Vec3b dark_color);
+cv::Mat CreateLut(const cv::Vec3b &saturation_color, const cv::Vec3b &dark_color);
 
 /**
  * @brief Structure used to store command line arguments parsed by the user.
@@ -195,7 +197,7 @@ struct CommandLineArguments
  * @param xi_img input ximea image
  * @param mat_img output cv::Mat image
  */
-void XIIMGtoMat(XI_IMG &xi_img, cv::Mat &mat_img);
+void XIIMGtoMat(const XI_IMG &xi_img, cv::Mat &mat_img);
 
 /**
  * Generates a timestamp with the format `yyyyMMdd_hh-mm-ss-zzz`

--- a/src/util.h
+++ b/src/util.h
@@ -11,12 +11,8 @@
 #include <QMap>
 #include <QString>
 #include <boost/log/trivial.hpp>
-#include <cstdio>
-#include <iostream>
 #include <msgpack.hpp>
-#include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include <stdexcept>
 #include <string>
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -97,6 +97,7 @@ class FileImage
     /**
      * Opens a file and throws runtime error when opening fails
      * @param filePath path to file to open
+     * @throws XiLensError when initializing file fails
      */
     FileImage(const char *filePath, unsigned int imageHeight, unsigned int imageWidth);
 
@@ -118,6 +119,16 @@ class FileImage
      *
      */
     void AppendMetadata();
+
+    /**
+     * Checks for each expected metadata key, that the length matches the number of images
+     * in the file. Returns false if metadata has inconsistent shape or if it does not exist for any key.
+     *
+     * @param src BLOSC ND-Array to check.
+     * @return `true` if the metadata is consistent and `false` if the metadata shape is missing or shape is
+     * inconsistent.
+     */
+    static bool CheckFileMetadata(const b2nd_array_t *src);
 };
 
 /**
@@ -128,6 +139,15 @@ class FileImage
  * @param newData data package with `Message Pack <https://msgpack.org/>`_.
  */
 void AppendBLOSCVLMetadata(b2nd_array_t *src, const char *key, msgpack::sbuffer &newData);
+
+/**
+ * Unpacks the metadata in array and computes the number of elements corresponding to the specified key.
+ *
+ * @param src BLOSC ND-Array from which the metadata should be analyzed.
+ * @param key Identifier of the metadata layer from which the number of elements is desired.
+ * @return number of elements in metadata layer or negative value if an error occurred.
+ */
+int GetBLOSCVLMetadataLength(const b2nd_array_t *src, const char *key);
 
 /**
  * Packs and appends the metadata associated with a BLOSC NDarray

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -3,11 +3,8 @@
  * License: see LICENSE.md file
  *******************************************************/
 
-#include <QColor>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QSlider>
-#include <QStyle>
 #include <QStyleOptionSlider>
 #include <QToolTip>
 

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -16,10 +16,10 @@ QSliderLabeled::QSliderLabeled(QWidget *parent) : QSlider(parent)
 
 void QSliderLabeled::ApplyStyleSheet()
 {
-    QFontMetrics fm(font());
-    QString maxLabel = QString::number(maximum());
-    int textWidth = fm.horizontalAdvance(maxLabel);
-    int textHeight = fm.height();
+    const QFontMetrics fm(font());
+    const QString maxLabel = QString::number(maximum());
+    const int textWidth = fm.horizontalAdvance(maxLabel);
+    const int textHeight = fm.height();
 
     if (orientation() == Qt::Orientation::Horizontal)
     {
@@ -51,10 +51,10 @@ void QSliderLabeled::paintEvent(QPaintEvent *event)
     QPainter painter(this);
     painter.setPen(m_penColor);
 
-    int min = minimum();
-    int max = maximum();
+    const int min = minimum();
+    const int max = maximum();
     int interval = tickInterval();
-    auto intervalAtMaxLabels = (max - min) / m_maxNumberOfLabels;
+    const auto intervalAtMaxLabels = (max - min) / m_maxNumberOfLabels;
     // Modify the interval if the current interval would generate too many labels in the slider.
     if (interval == 0 || (max - min) / interval > m_maxNumberOfLabels)
     {
@@ -67,7 +67,7 @@ void QSliderLabeled::paintEvent(QPaintEvent *event)
         {
             int xpos = QStyle::sliderPositionFromValue(min, max, i, width() - 2 * m_grooveMargin) + m_grooveMargin;
             QString label = QString::number(i);
-            int textWidth = painter.fontMetrics().horizontalAdvance(label);
+            const int textWidth = painter.fontMetrics().horizontalAdvance(label);
 
             // Ensure labels are not drawn off the widget's area
             xpos = qBound(0, xpos, width()) - textWidth / 2;
@@ -86,7 +86,7 @@ void QSliderLabeled::paintEvent(QPaintEvent *event)
 
             // to position the text, we need the bounding box and not just the text height
             QRect textRect = painter.fontMetrics().tightBoundingRect(label);
-            int textHeight = textRect.height();
+            const int textHeight = textRect.height();
 
             // Ensure labels are not drawn off the widget's area
             ypos = qBound(0, ypos, height()) + textHeight / 2;
@@ -105,21 +105,21 @@ void QSliderLabeled::mouseMoveEvent(QMouseEvent *event)
 
 void QSliderLabeled::UpdatePainterPen()
 {
-    QColor penColor = isEnabled() ? QColor(255, 215, 64) : QColor(79, 91, 98);
+    const QColor penColor = isEnabled() ? QColor(255, 215, 64) : QColor(79, 91, 98);
     m_penColor = penColor;
 }
 
-void QSliderLabeled::SetGrooveMargin(int value)
+void QSliderLabeled::SetGrooveMargin(const int value)
 {
     m_grooveMargin = value;
 }
 
-void QSliderLabeled::SetMaxNumberOfLabels(int value)
+void QSliderLabeled::SetMaxNumberOfLabels(const int value)
 {
     m_maxNumberOfLabels = value;
 }
 
-void QSliderLabeled::SetSliderSpread(int value)
+void QSliderLabeled::SetSliderSpread(const int value)
 {
     m_sliderSpread = value;
 }

--- a/src/widgets.h
+++ b/src/widgets.h
@@ -9,7 +9,6 @@
 #include <QColor>
 #include <QEvent>
 #include <QSlider>
-#include <QStyle>
 
 /**
  * @brief Custom slider widget used to display text labels along the slider

--- a/src/xiAPIWrapper.h
+++ b/src/xiAPIWrapper.h
@@ -17,6 +17,8 @@
 class XiAPIWrapper
 {
   public:
+    virtual ~XiAPIWrapper() = default;
+
     virtual int xiGetParamString(IN HANDLE hDevice, const char *prm, void *val, DWORD size)
     {
         return ::xiGetParamString(hDevice, prm, val, size);

--- a/tests/bloscTest.cpp
+++ b/tests/bloscTest.cpp
@@ -10,6 +10,7 @@
 #include <xiApi.h>
 
 #include <chrono>
+#include <constants.h>
 #include <msgpack.hpp>
 
 #include "src/util.h"
@@ -22,7 +23,7 @@
         throw std::runtime_error(errormsg.str());                                                                      \
     }
 
-void CreateBLOSCArray(char *urlpath)
+void CreateBLOSCArray(char *urlpath, bool consistentMetadata)
 {
     blosc2_init();
     auto *image = new XI_IMG;
@@ -119,6 +120,23 @@ void CreateBLOSCArray(char *urlpath)
     msgpack::pack(sbufString, stringArray);
     AppendBLOSCVLMetadata(src, "stringMetadata", sbufString);
 
+    for (auto key : EXPECTED_METADATA_KEYS)
+    {
+        std::vector<int> metadata;
+        if (consistentMetadata)
+        {
+            metadata.resize(N_images);
+        }
+        else
+        {
+            metadata.resize(N_images - 1);
+        }
+        std::iota(metadata.begin(), metadata.end(), 0);
+        msgpack::sbuffer metadataBuffer;
+        msgpack::pack(metadataBuffer, metadata);
+        AppendBLOSCVLMetadata(src, key.toUtf8().constData(), metadataBuffer);
+    }
+
     b2nd_free(src);
     b2nd_free_ctx(ctx);
     blosc2_destroy();
@@ -130,7 +148,7 @@ TEST(BLOSC, BloscAppend)
 {
     char *urlpath = strdup("test_image_dataset.b2nd");
     blosc2_remove_urlpath(urlpath);
-    CreateBLOSCArray(urlpath);
+    CreateBLOSCArray(urlpath, true);
     blosc2_remove_urlpath(urlpath);
 }
 
@@ -138,7 +156,37 @@ TEST(BLOSC, BloscAppendToExistingFile)
 {
     char *urlpath = strdup("test_image_dataset.b2nd");
     blosc2_remove_urlpath(urlpath);
-    CreateBLOSCArray(urlpath);
-    CreateBLOSCArray(urlpath);
+    CreateBLOSCArray(urlpath, true);
+    CreateBLOSCArray(urlpath, true);
     blosc2_remove_urlpath(urlpath);
+}
+
+TEST(BLOSC, BloscCheckMetadata)
+{
+    char *urlpath = strdup("test_image_dataset_consistent_metadata.b2nd");
+    blosc2_remove_urlpath(urlpath);
+    CreateBLOSCArray(urlpath, true);
+    b2nd_array_t *src;
+    auto result = b2nd_open(urlpath, &src);
+    if (result < 0)
+    {
+        throw std::runtime_error("Error opening file");
+    }
+    result = FileImage::CheckFileMetadata(src);
+    ASSERT_TRUE(result);
+}
+
+TEST(BLOSC, BloscCheckInconsistentMetadata)
+{
+    char *urlpath = strdup("test_image_dataset_consistent_metadata.b2nd");
+    blosc2_remove_urlpath(urlpath);
+    CreateBLOSCArray(urlpath, false);
+    b2nd_array_t *src;
+    auto result = b2nd_open(urlpath, &src);
+    if (result < 0)
+    {
+        throw std::runtime_error("Error opening file");
+    }
+    result = FileImage::CheckFileMetadata(src);
+    ASSERT_FALSE(result);
 }

--- a/tests/utilTest.cpp
+++ b/tests/utilTest.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "src/constants.h"
+#include "src/errors.h"
 #include "src/util.h"
 
 TEST(UtilTest, HandleResultTest)
@@ -257,4 +258,35 @@ TEST_F(FileImageWriteTest, AppendMetadataTwice)
     }
     fileImage.AppendMetadata();
     blosc2_destroy();
+    blosc2_remove_urlpath(urlpath);
+}
+
+TEST_F(FileImageWriteTest, ExpectThrowOnInconsistentMetadata)
+{
+    uint32_t nrImages = 10;
+    XI_IMG xiImage;
+    xiImage.width = 64;
+    xiImage.height = 64;
+    xiImage.exposure_time_us = 40000;
+    xiImage.bp = malloc(static_cast<size_t>(xiImage.width) * static_cast<size_t>(xiImage.height) * sizeof(uint16_t));
+    std::fill_n((uint16_t *)xiImage.bp, xiImage.width * xiImage.height, 12345);
+    const char *urlpath = strdup("test_image_inconsistent_metadata.b2nd");
+
+    blosc2_init();
+    blosc2_remove_urlpath(urlpath);
+
+    FileImage fileImage(urlpath, xiImage.height, xiImage.width);
+    QMap<QString, float> additionalMetadata = {{"extraMetadata", 1.0}};
+    for (int i = 0; i < nrImages; i++)
+    {
+        fileImage.WriteImageData(xiImage, additionalMetadata);
+    }
+    fileImage.AppendMetadata();
+
+    auto new_data = std::vector<int>{1};
+    PackAndAppendMetadata(fileImage.m_src, EXPECTED_METADATA_KEYS[0].toUtf8().constData(), new_data);
+
+    EXPECT_THROW(FileImage(urlpath, xiImage.height, xiImage.width), XiLensError);
+
+    blosc2_remove_urlpath(urlpath);
 }


### PR DESCRIPTION
## Description
If a file exists and an attempt is made to append data to it, the metadata of the file is first checked to make sure that it is consistent before appending new images and metadata. If the metadata is inconsistent, a pop-up window is displayed and new data is not appended, a new file name needs to be indicated in this case. 

## Summary of additional changes: 
- Refactors project to use `const` qualifier where possible 
- Refactors snapshot recording functionality to make the code easier to understand and splits functionalities into smaller modules. 
- Removes unused includes

## Related Issue
#52 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
