### PR TITLE
Fixes app crash on exposure slider rapid change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removes unused includes
+- Removes exposure slider
 
 ### Fixed
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -57,12 +57,6 @@ MainWindow::MainWindow(QWidget *parent, const std::shared_ptr<XiAPIWrapper> &xiA
     m_baseFolderPath = QDir::cleanPath(QDir::homePath());
     ui->baseFolderLineEdit->insert(this->GetBaseFolder());
 
-    // synchronize expSlider and exposure checkbox
-    const QSlider *expSlider = ui->exposureSlider;
-    QSpinBox *expSpinBox = ui->exposureSpinBox;
-    // set default values
-    expSpinBox->setValue(expSlider->value());
-
     LOG_XILENS(info) << "test mode (recording everything to same file) is set to: " << m_testMode << "\n";
     this->SetUpConnections();
     EnableUi(false);
@@ -74,8 +68,6 @@ void MainWindow::SetUpConnections()
                                               &MainWindow::HandleSnapshotButtonClicked));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->recordSnapshotToolButton, &QArrowToolButton::ArrowClicked, this,
                                               &MainWindow::HandleSnapshotToolButtonArrowClicked));
-    HANDLE_CONNECTION_RESULT(
-        QObject::connect(ui->exposureSlider, &QSlider::valueChanged, this, &MainWindow::HandleExposureValueChanged));
     HANDLE_CONNECTION_RESULT(
         QObject::connect(ui->exposureSpinBox, &QSpinBox::valueChanged, this, &MainWindow::HandleExposureValueChanged));
     HANDLE_CONNECTION_RESULT(QObject::connect(ui->viewerImageSlider, &QSlider::valueChanged, this,
@@ -199,8 +191,6 @@ void MainWindow::EnableUi(const bool enable) const
 
 void MainWindow::SetUpCustomUiComponents() const
 {
-    //
-    this->ui->exposureSlider->SetLabelInterval(50);
     // reload camera list button
     QIcon reloadButtonIcon;
     reloadButtonIcon.addFile(":/icon/theme/primary/reload.svg", QSize(), QIcon::Normal);
@@ -590,7 +580,6 @@ void MainWindow::ViewerWorkerThreadFunc()
 void MainWindow::UpdateExposure() const
 {
     // lock ui elements before updating them
-    const QSignalBlocker exposureSliderLock(ui->exposureSlider);
     const QSignalBlocker exposureSpinBoxLock(ui->exposureSpinBox);
     const int exposureMilliseconds = m_cameraInterface.m_camera->GetExposureMs();
     // update the estimated framerate
@@ -598,7 +587,6 @@ void MainWindow::UpdateExposure() const
     ui->hzLabel->setText(QString::number(1000.0 / (exposureMilliseconds * (nrSkipFrames + 1)), 'g', 2));
     // set exposure values to bot spinbox and slider
     ui->exposureSpinBox->setValue(exposureMilliseconds);
-    ui->exposureSlider->setValue(exposureMilliseconds);
 }
 
 void MainWindow::HandleRecordButtonClicked(const bool clicked)
@@ -994,7 +982,6 @@ void MainWindow::StopPollingThread()
 void MainWindow::HandleAutoexposureToolButtonClicked(const bool setAutoexposure) const
 {
     this->m_cameraInterface.m_camera->AutoExposure(setAutoexposure);
-    ui->exposureSlider->setEnabled(!setAutoexposure);
     ui->exposureSpinBox->setEnabled(!setAutoexposure);
     UpdateExposure();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -182,7 +182,6 @@ void MainWindow::EnableUi(const bool enable) const
 {
     EnableWidgetsInLayout(ui->mainUiVerticalLayout->layout(), enable);
     SetGraphicsViewScene();
-    EnableWidgetsInLayout(ui->exposureHorizontalLayout->layout(), enable);
     EnableWidgetsInLayout(ui->recordingControlsHorizontalLayout->layout(), enable);
     this->ui->logTextLineEdit->setEnabled(enable);
     this->m_bandSelectorSliderPopup->setEnabled(enable);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -415,7 +415,7 @@
                  </widget>
                 </item>
                 <item>
-                 <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="0,0,1,1">
+                 <layout class="QVBoxLayout" name="graphicsVerticalLayout" stretch="0,1,1">
                   <property name="spacing">
                    <number>0</number>
                   </property>
@@ -725,26 +725,6 @@
                        <enum>Qt::NoArrow</enum>
                       </property>
                      </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="exposureHorizontalLayout">
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <spacer name="horizontalSpacer_2">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
                     </item>
                    </layout>
                   </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -170,11 +170,11 @@
                      <item>
                       <layout class="QVBoxLayout" name="mainUiVerticalLayout" stretch="0,0,0,0,0">
                        <item>
-                        <layout class="QGridLayout" name="gridLayout">
+                        <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
                          <property name="topMargin">
                           <number>0</number>
                          </property>
-                         <item row="0" column="4">
+                         <item row="0" column="1" colspan="2">
                           <widget class="QLineEdit" name="baseFolderLineEdit">
                            <property name="toolTip">
                             <string>Folder where all data is stored</string>
@@ -190,13 +190,19 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="2" column="4">
+                         <item row="3" column="2">
                           <widget class="QSpinBox" name="skipFramesSpinBox">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                              <horstretch>0</horstretch>
                              <verstretch>0</verstretch>
                             </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>90</width>
+                             <height>0</height>
+                            </size>
                            </property>
                            <property name="maximumSize">
                             <size>
@@ -218,17 +224,7 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="2" column="3">
-                          <widget class="QLabel" name="skipFramesLabel">
-                           <property name="toolTip">
-                            <string>The number of images to skip before saving the next image to a file. For example, a value of 2 means every third image is saved.</string>
-                           </property>
-                           <property name="text">
-                            <string>Skip frames</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="4">
+                         <item row="1" column="1" colspan="2">
                           <widget class="QLineEdit" name="fileNameLineEdit">
                            <property name="toolTip">
                             <string>File name used to store the video data</string>
@@ -241,23 +237,7 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="0" column="3">
-                          <widget class="QPushButton" name="baseFolderButton">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="toolTip">
-                            <string>Select folder where all data is organized</string>
-                           </property>
-                           <property name="text">
-                            <string>Save folder</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="1" column="3">
+                         <item row="1" column="0">
                           <widget class="QLabel" name="fileNameLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -273,6 +253,85 @@
                            </property>
                            <property name="alignment">
                             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="1">
+                          <widget class="QLabel" name="skipFramesLabel">
+                           <property name="toolTip">
+                            <string>The number of images to skip before saving the next image to a file. For example, a value of 2 means every third image is saved.</string>
+                           </property>
+                           <property name="text">
+                            <string>Skip frames</string>
+                           </property>
+                           <property name="alignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QPushButton" name="baseFolderButton">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="toolTip">
+                            <string>Select folder where all data is organized</string>
+                           </property>
+                           <property name="text">
+                            <string>Save folder</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="2">
+                          <widget class="QSpinBox" name="exposureSpinBox">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>90</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="toolTip">
+                            <string>Exposure time in milliseconds</string>
+                           </property>
+                           <property name="layoutDirection">
+                            <enum>Qt::LeftToRight</enum>
+                           </property>
+                           <property name="autoFillBackground">
+                            <bool>false</bool>
+                           </property>
+                           <property name="frame">
+                            <bool>true</bool>
+                           </property>
+                           <property name="alignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <property name="minimum">
+                            <number>5</number>
+                           </property>
+                           <property name="maximum">
+                            <number>500</number>
+                           </property>
+                           <property name="value">
+                            <number>40</number>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="1">
+                          <widget class="QLabel" name="exposureLabel">
+                           <property name="text">
+                            <string>Exposure (ms)</string>
+                           </property>
+                           <property name="alignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                            </property>
                           </widget>
                          </item>
@@ -675,82 +734,17 @@
                      <number>5</number>
                     </property>
                     <item>
-                     <widget class="QLabel" name="exposureLabel">
-                      <property name="text">
-                       <string>Exposure (ms)</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSpinBox" name="exposureSpinBox">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>90</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="toolTip">
-                       <string>Exposure time in milliseconds</string>
-                      </property>
-                      <property name="layoutDirection">
-                       <enum>Qt::LeftToRight</enum>
-                      </property>
-                      <property name="autoFillBackground">
-                       <bool>false</bool>
-                      </property>
-                      <property name="frame">
-                       <bool>true</bool>
-                      </property>
-                      <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                      </property>
-                      <property name="minimum">
-                       <number>5</number>
-                      </property>
-                      <property name="maximum">
-                       <number>500</number>
-                      </property>
-                      <property name="value">
-                       <number>40</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSliderLabeled" name="exposureSlider">
-                      <property name="toolTip">
-                       <string>Exposure time in milliseconds</string>
-                      </property>
-                      <property name="minimum">
-                       <number>5</number>
-                      </property>
-                      <property name="maximum">
-                       <number>500</number>
-                      </property>
-                      <property name="value">
-                       <number>40</number>
-                      </property>
+                     <spacer name="horizontalSpacer_2">
                       <property name="orientation">
                        <enum>Qt::Horizontal</enum>
                       </property>
-                      <property name="invertedAppearance">
-                       <bool>false</bool>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
                       </property>
-                      <property name="invertedControls">
-                       <bool>false</bool>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>10</number>
-                      </property>
-                     </widget>
+                     </spacer>
                     </item>
                    </layout>
                   </item>


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Removes exposure slider because it is at the moment an unused feature that only brings more problems than solutions.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#55 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
