### PR TITLE
Adds c-blosc2 as submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v4.1.7
+        with:
+          submodules: 'recursive'
       - name: Install apt dependencies
         run: |
           sudo apt update
@@ -33,7 +35,7 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          CTEST_OUTPUT_ON_FAILURE=1 xvfb-run -a --server-args="-screen 0 1024x768x24" make test -j
+          CTEST_OUTPUT_ON_FAILURE=1 xvfb-run -a --server-args="-screen 0 1024x768x24" ctest -j -L XilensTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and install DEB package
@@ -72,14 +74,6 @@ jobs:
           cd package
           sed -i '/^[^#]/ s/\(^.*udevadm control --reload.*$\)/#\ \1/' scripts/install_steps
           sudo ./install
-          cd ..
-          git clone https://github.com/Blosc/c-blosc2.git
-          cd c-blosc2
-          git checkout v2.15.1
-          mkdir build
-          cd build
-          cmake -DCMAKE_INSTALL_PREFIX=/usr ..
-          sudo make install -j
       - name: Check app installation
         run: |
           xilens --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          CTEST_OUTPUT_ON_FAILURE=1 xvfb-run -a --server-args="-screen 0 1024x768x24" ctest -j -L XilensTests
+          CTEST_OUTPUT_ON_FAILURE=1 xvfb-run -a --server-args="-screen 0 1024x768x24" ctest -L XilensTests -j
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and install DEB package

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: 'recursive'
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/c-blosc2"]
+	path = submodules/c-blosc2
+	url = https://github.com/Blosc/c-blosc2.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New check for metadata to make sure metadata is consistent before appending data to an existing file.
 - New option to not display slider tick labels on the custom QSliderLabeled component.
 - New custom Widgets to display controls like sliders on pup-up windows when clicking on a tool button.
+- New custom Widget to control overexposure and underexposure colors and limits.
+- New custom Widget to manually select the image channels used to create an RGB image reconstruction for spectral cameras.
+- New separator between displayed images to enlarge either one of them when needed.
 
 ### Changed
 
 - Refactors snapshot recording method to make it more modular.
 - Moves controls from toolbox to ToolButtons.
 - Expands image viewer to cover the entire area of the UI.
+- Integrates blosc2 as a submodule of xilens to simplify development and easier use of xilens.
 
 ### Removed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,6 @@ endif()
 #-----------------------------------------------------------------------------------------------------------------------
 # Boost
 find_package(Boost REQUIRED system thread timer chrono log filesystem)
-# BLOSC2
-find_package(Blosc2 2.15.1 CONFIG REQUIRED)
 # Message pack for metadata serialization
 find_package(msgpack REQUIRED)
 # Qt
@@ -74,6 +72,13 @@ find_package(OpenCV REQUIRED COMPONENTS core imgproc highgui)
 # XIMEA API
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 find_package(Ximea REQUIRED)
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Submodules
+#-----------------------------------------------------------------------------------------------------------------------
+# C-Blosc2
+add_subdirectory(submodules/c-blosc2)
+
 #-----------------------------------------------------------------------------------------------------------------------
 # XiLens library build
 #-----------------------------------------------------------------------------------------------------------------------
@@ -117,12 +122,13 @@ add_library(XILENS_LIB ${LIBTYPE}
         ${XILENS_LIB_UI_MOC}
 )
 target_include_directories(XILENS_LIB PUBLIC ${Ximea_INCLUDE_DIRS})
+target_include_directories(XILENS_LIB PUBLIC ${CMAKE_SOURCE_DIR}/submodules/c-blosc2/include ${CMAKE_SOURCE_DIR}/submodules/c-blosc2/plugins/NDim/include)
 target_link_libraries(XILENS_LIB Qt6::Widgets Qt6::Svg)
 target_link_libraries(XILENS_LIB Boost::system Boost::thread Boost::timer Boost::chrono Boost::log Boost::filesystem)
 target_link_libraries(XILENS_LIB ${OpenCV_LIBS})
 target_link_libraries(XILENS_LIB ${Boost_LIBRARIES})
 target_link_libraries(XILENS_LIB ${Ximea_LIBRARIES})
-target_link_libraries(XILENS_LIB Blosc2::blosc2_shared)
+target_link_libraries(XILENS_LIB blosc2_shared)
 
 #-----------------------------------------------------------------------------------------------------------------------
 # XiLens executable
@@ -174,9 +180,9 @@ add_executable(
         tests/constantsTest.cpp
         ${XILENS_LIB_UI_MOC}
 )
-target_link_libraries(XILENS_TESTS GTest::gtest_main XILENS_LIB Blosc2::blosc2_shared)
+target_link_libraries(XILENS_TESTS GTest::gtest_main XILENS_LIB)
 include(GoogleTest)
-gtest_discover_tests(XILENS_TESTS)
+gtest_discover_tests(XILENS_TESTS PROPERTIES LABELS "XilensTests")
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Packaging

--- a/docs/developer_guidelines.md
+++ b/docs/developer_guidelines.md
@@ -25,7 +25,7 @@ The docstrings follow the ``Doxygen`` format, while the code style follows the `
 ## Tests
 As mentioned before, your code should ideally be tested thoroughly. For this we use `GoogleTests`. You can find
 examples of it in the already created unittests in our repository.
-To run all tests you can run ``make test`` from the build directory after correctly configuring it.
+To run all tests you can run ``ctest -L XilensTests`` from the build directory after correctly configuring it.
 
 ## Documentation
 Ideally all your code should be documented, the markup used for the documentation is [Doxygen-style](https://www

--- a/docs/developer_guidelines.md
+++ b/docs/developer_guidelines.md
@@ -25,7 +25,7 @@ The docstrings follow the ``Doxygen`` format, while the code style follows the `
 ## Tests
 As mentioned before, your code should ideally be tested thoroughly. For this we use `GoogleTests`. You can find
 examples of it in the already created unittests in our repository.
-To run all tests you can run ``ctest -L XilensTests`` from the build directory after correctly configuring it.
+To run all tests you can run ``ctest -L XilensTests -j`` from the build directory after correctly configuring it.
 
 ## Documentation
 Ideally all your code should be documented, the markup used for the documentation is [Doxygen-style](https://www

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,7 @@ From the root directory of ``XiLens`` do the following.
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr  ..
 make all -j
-ctest # to check that all tests pass
+ctest -L XilensTests -j # to check that all tests pass
 sudo make install # installs the desktop app on the system and can be accessed from the app launcher
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@ sudo apt install ./xilens*.deb
 This will install ``XiLens`` and its dependencies that are available in ``apt``.
 
 !!! warning "Dependencies"
-    ``XiLens`` still depends on ``BLOSC2`` and `XiAPI`. These packages are not available via `apt`, which is why they
+    ``XiLens`` still depends on `XiAPI`. This package is not available via `apt`, which is why they
     are not installed by `apt` when installing the `.deb` package.
     These additional dependencies can be installed by running:
 
@@ -37,18 +37,18 @@ build as in the following commands.
 
 !!! warning "Installation directory"
 
-    You should run this from a directory where BLOSC2 and XiAPI will be downloaded.
+    You should run this from a directory where XiAPI will be downloaded.
 
 ```bash
 chmod +x install_dependencies.sh
 sudo ./install_dependencies.sh --user
 ```
 
-This takes care of installing dependencies including the xiAPI package provided by XIMEA and BLOSC2.
+This takes care of installing dependencies including the xiAPI package provided by XIMEA.
 
 !!! warning "User vs. Development dependencies"
 
-    The previous script will install ``BLOSC2`` and ``XiAPI`` on your system!
+    The previous script will install ``XiAPI`` on your system!
     If you are building the application for development purposes, you should remove the flag `--user` to install the
     development dependencies instead.
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -19,12 +19,3 @@ cd package || exit
 sed -i '/^[^#]/ s/\(^.*udevadm control --reload.*$\)/#\ \1/' scripts/install_steps
 ./install
 cd ..
-
-# install BLOSC2
-git clone https://github.com/Blosc/c-blosc2.git
-cd c-blosc2 || exit
-git checkout v2.15.1
-mkdir build
-cd build || exit
-cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
-cmake --build . --target install --parallel

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  XiLens integrates a new image viewer and supports new XIMEA cameras.
+  XiLens integrates a simplified UI through new UI tool buttons and separators that can be dragged around to create a simpler interface when desired.
 {% endblock %}

--- a/tests/bloscTest.cpp
+++ b/tests/bloscTest.cpp
@@ -146,7 +146,7 @@ void CreateBLOSCArray(char *urlpath, bool consistentMetadata)
 
 TEST(BLOSC, BloscAppend)
 {
-    char *urlpath = strdup("test_image_dataset.b2nd");
+    char *urlpath = strdup("test_image_append_to_new_file_dataset.b2nd");
     blosc2_remove_urlpath(urlpath);
     CreateBLOSCArray(urlpath, true);
     blosc2_remove_urlpath(urlpath);
@@ -154,7 +154,7 @@ TEST(BLOSC, BloscAppend)
 
 TEST(BLOSC, BloscAppendToExistingFile)
 {
-    char *urlpath = strdup("test_image_dataset.b2nd");
+    char *urlpath = strdup("test_image_append_to_existing_file_dataset.b2nd");
     blosc2_remove_urlpath(urlpath);
     CreateBLOSCArray(urlpath, true);
     CreateBLOSCArray(urlpath, true);
@@ -163,7 +163,7 @@ TEST(BLOSC, BloscAppendToExistingFile)
 
 TEST(BLOSC, BloscCheckMetadata)
 {
-    char *urlpath = strdup("test_image_dataset_consistent_metadata.b2nd");
+    char *urlpath = strdup("test_image_consistent_metadata_dataset.b2nd");
     blosc2_remove_urlpath(urlpath);
     CreateBLOSCArray(urlpath, true);
     b2nd_array_t *src;
@@ -178,7 +178,7 @@ TEST(BLOSC, BloscCheckMetadata)
 
 TEST(BLOSC, BloscCheckInconsistentMetadata)
 {
-    char *urlpath = strdup("test_image_dataset_consistent_metadata.b2nd");
+    char *urlpath = strdup("test_image_inconsistent_metadata_dataset.b2nd");
     blosc2_remove_urlpath(urlpath);
     CreateBLOSCArray(urlpath, false);
     b2nd_array_t *src;

--- a/tests/utilTest.cpp
+++ b/tests/utilTest.cpp
@@ -81,7 +81,7 @@ TEST_F(FileImageWriteTest, CheckContentsAfterWriting)
     xiImage.exposure_time_us = 40000;
     xiImage.bp = malloc(static_cast<size_t>(xiImage.width) * static_cast<size_t>(xiImage.height) * sizeof(uint16_t));
     std::fill_n((uint16_t *)xiImage.bp, xiImage.width * xiImage.height, 12345);
-    const char *urlpath = strdup("test_image.b2nd");
+    const char *urlpath = strdup("test_image_contents_after_writing.b2nd");
 
     blosc2_init();
     blosc2_remove_urlpath(urlpath);
@@ -240,7 +240,7 @@ TEST_F(FileImageWriteTest, AppendMetadataTwice)
     xiImage.exposure_time_us = 40000;
     xiImage.bp = malloc(static_cast<size_t>(xiImage.width) * static_cast<size_t>(xiImage.height) * sizeof(uint16_t));
     std::fill_n((uint16_t *)xiImage.bp, xiImage.width * xiImage.height, 12345);
-    const char *urlpath = strdup("test_image.b2nd");
+    const char *urlpath = strdup("test_image_append_metadata_twice.b2nd");
 
     blosc2_init();
     blosc2_remove_urlpath(urlpath);
@@ -272,7 +272,7 @@ TEST_F(FileImageWriteTest, ExpectThrowOnInconsistentMetadata)
     xiImage.exposure_time_us = 40000;
     xiImage.bp = malloc(static_cast<size_t>(xiImage.width) * static_cast<size_t>(xiImage.height) * sizeof(uint16_t));
     std::fill_n((uint16_t *)xiImage.bp, xiImage.width * xiImage.height, 12345);
-    const char *urlpath = strdup("test_image_inconsistent_metadata.b2nd");
+    const char *urlpath = strdup("test_image_throw_on_inconsistent_metadata.b2nd");
 
     blosc2_init();
     blosc2_remove_urlpath(urlpath);


### PR DESCRIPTION
## Description

Adds blosc2 as a submodule of `xilens`. Updates install_dependencies.sh, docs/, and GitHub actions accordingly.

## Related Issue

#47 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've updated the code style using the `pre-commit hooks`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring for all the methods and classes that I used.
